### PR TITLE
update terraform to 0.12

### DIFF
--- a/terraform-config-files/network.tf
+++ b/terraform-config-files/network.tf
@@ -14,54 +14,54 @@
 # If not, see https://github.com/jonrau1/ElectricEye/blob/master/LICENSE.
 
 resource "aws_vpc" "Electric_Eye_VPC" {
-  cidr_block           = "${var.Electric_Eye_VPC_CIDR}"
+  cidr_block           = var.Electric_Eye_VPC_CIDR
   enable_dns_support   = true
   enable_dns_hostnames = true
-  tags {
-      Name = "${var.Electric_Eye_VPC_Name_Tag}"
+  tags = {
+      Name = var.Electric_Eye_VPC_Name_Tag
   }
 }
 resource "aws_subnet" "Electric_Eye_Public_Subnets" {
-  count                   = "${var.Network_Resource_Count}"
-  vpc_id                  = "${aws_vpc.Electric_Eye_VPC.id}"
-  cidr_block              = "${cidrsubnet(aws_vpc.Electric_Eye_VPC.cidr_block, 8, var.Network_Resource_Count + count.index)}"
-  availability_zone       = "${data.aws_availability_zones.Available_AZ.names[count.index]}"
+  count                   = var.Network_Resource_Count
+  vpc_id                  = aws_vpc.Electric_Eye_VPC.id
+  cidr_block              = cidrsubnet(aws_vpc.Electric_Eye_VPC.cidr_block, 8, var.Network_Resource_Count + count.index)
+  availability_zone       = data.aws_availability_zones.Available_AZ.names[count.index]
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "${var.Electric_Eye_VPC_Name_Tag}-PUB-Subnet-${element(data.aws_availability_zones.Available_AZ.names, count.index)}"
   }
 }
 resource "aws_internet_gateway" "Electric_Eye_IGW" {
-  vpc_id = "${aws_vpc.Electric_Eye_VPC.id}"
-  tags {
+  vpc_id = aws_vpc.Electric_Eye_VPC.id
+  tags = {
       Name = "${var.Electric_Eye_VPC_Name_Tag}-IGW"
   }
 }
 resource "aws_route_table" "Electric_Eye_Public_RTB" {
-  count  = "${var.Network_Resource_Count}"
-  vpc_id = "${aws_vpc.Electric_Eye_VPC.id}"
+  count  = var.Network_Resource_Count
+  vpc_id = aws_vpc.Electric_Eye_VPC.id
   route {
       cidr_block = "0.0.0.0/0"
-      gateway_id = "${aws_internet_gateway.Electric_Eye_IGW.id}"
+      gateway_id = aws_internet_gateway.Electric_Eye_IGW.id
   }
-  tags {
+  tags = {
     Name = "${var.Electric_Eye_VPC_Name_Tag}-PUB-RTB-${element(aws_subnet.Electric_Eye_Public_Subnets.*.id, count.index)}"
   }
 }
 resource "aws_vpc_endpoint" "Electric_Eye_Gateway_S3" {
-  vpc_id            = "${aws_vpc.Electric_Eye_VPC.id}"
+  vpc_id            = aws_vpc.Electric_Eye_VPC.id
   service_name      = "com.amazonaws.${var.AWS_Region}.s3"
   vpc_endpoint_type = "Gateway"
-  route_table_ids   = ["${aws_route_table.Electric_Eye_Public_RTB.*.id}"]
+  route_table_ids   = aws_route_table.Electric_Eye_Public_RTB[*].id
   tags = {
       Name = "${var.Electric_Eye_VPC_Name_Tag}-S3-Endpoint"
   }
 }
 resource "aws_vpc_endpoint" "Electric_Eye_Interface_Interface_ECR-DKR" {
-  vpc_id              = "${aws_vpc.Electric_Eye_VPC.id}"
+  vpc_id              = aws_vpc.Electric_Eye_VPC.id
   service_name        = "com.amazonaws.${var.AWS_Region}.ecr.dkr"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = ["${aws_subnet.Electric_Eye_Public_Subnets.*.id}"]
+  subnet_ids          = aws_subnet.Electric_Eye_Public_Subnets[*].id
   security_group_ids  = ["${aws_security_group.Electric_Eye_Sec_Group.id}"]
   private_dns_enabled = true
   tags = {
@@ -69,15 +69,15 @@ resource "aws_vpc_endpoint" "Electric_Eye_Interface_Interface_ECR-DKR" {
   }
 }
 resource "aws_route_table_association" "Public_Subnet_Association" {
-  count          = "${var.Network_Resource_Count}"
-  subnet_id      = "${element(aws_subnet.Electric_Eye_Public_Subnets.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.Electric_Eye_Public_RTB.*.id, count.index)}"
+  count          = var.Network_Resource_Count
+  subnet_id      = element(aws_subnet.Electric_Eye_Public_Subnets.*.id, count.index)
+  route_table_id = element(aws_route_table.Electric_Eye_Public_RTB.*.id, count.index)
 }
 resource "aws_flow_log" "Electric_Eye_VPC_Flow_Log" {
-  iam_role_arn    = "${aws_iam_role.Electric_Eye_FlowLogs_to_CWL_Role.arn}"
-  log_destination = "${aws_cloudwatch_log_group.Electric_Eye_FlowLogs_CWL_Group.arn}"
+  iam_role_arn    = aws_iam_role.Electric_Eye_FlowLogs_to_CWL_Role.arn
+  log_destination = aws_cloudwatch_log_group.Electric_Eye_FlowLogs_CWL_Group.arn
   traffic_type    = "ALL"
-  vpc_id          = "${aws_vpc.Electric_Eye_VPC.id}"
+  vpc_id          = aws_vpc.Electric_Eye_VPC.id
 }
 resource "aws_cloudwatch_log_group" "Electric_Eye_FlowLogs_CWL_Group" {
   name = "FlowLogs/${var.Electric_Eye_VPC_Name_Tag}"
@@ -102,7 +102,7 @@ EOF
 }
 resource "aws_iam_role_policy" "Electric_Eye_FlowLogs_to_CWL_Role_Policy" {
   name = "${var.Electric_Eye_VPC_Name_Tag}-flowlog-role-policy"
-  role = "${aws_iam_role.Electric_Eye_FlowLogs_to_CWL_Role.id}"
+  role = aws_iam_role.Electric_Eye_FlowLogs_to_CWL_Role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -123,15 +123,15 @@ resource "aws_iam_role_policy" "Electric_Eye_FlowLogs_to_CWL_Role_Policy" {
 EOF
 }
 resource "aws_default_security_group" "Default_Security_Group" {
-  vpc_id = "${aws_vpc.Electric_Eye_VPC.id}"
-  tags {
+  vpc_id = aws_vpc.Electric_Eye_VPC.id
+  tags = {
     Name = "DEFAULT_DO_NOT_USE"
   }
 }
 resource "aws_security_group" "Electric_Eye_Sec_Group" {
   name        = "${var.Electric_Eye_VPC_Name_Tag}-sec-group"
   description = "ElectricEye Security Group - Managed by Terraform"
-  vpc_id      = "${aws_vpc.Electric_Eye_VPC.id}"
+  vpc_id      = aws_vpc.Electric_Eye_VPC.id
   ingress {
     from_port   = 443
     to_port     = 443
@@ -144,7 +144,7 @@ resource "aws_security_group" "Electric_Eye_Sec_Group" {
     protocol        = "-1"
     cidr_blocks     = ["0.0.0.0/0"]
   }
-  tags {
+  tags = {
       Name = "${var.Electric_Eye_VPC_Name_Tag}-sec-group"
   }
 }


### PR DESCRIPTION
This pull request updates Terraform code that would prevent a `terraform apply` from occurring or causes deprecation warnings when using Terraform v0.12.x.

Working Environment Setup: 

To ensure that these changes do not break any pre-existing ElectricEye environments, prior to changes the following environment was setup/deployed using Terraform v0.11.14. 

Once all ElectricEye deployment steps were completed, the environment was updated to Terraform v0.12.28 and code was modified. 

Afterwards `terraform apply` was run to ensure no changes to infrastructure were needed.

Note that this PR only updates code that would prevent a `terraform apply` from occurring or causes deprecation warnings when using Terraform v0.12.x.

This PR does not convert all Terraform code to any new optional ways of doing things introduced in Terraform 0.12.x.