### PR TITLE
Fixes for Terraform 0.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ Before starting [attach this IAM policy](https://github.com/jonrau1/ElectricEye/
 
 In this stage we will install and deploy the ElectricEye infrastructure via Terraform. To securely backup your state file, you should explore the usage of a [S3 backend](https://www.terraform.io/docs/backends/index.html), this is also described in this [AWS Security Blog post](https://aws.amazon.com/blogs/security/how-use-ci-cd-deploy-configure-aws-security-services-terraform/).
 
-1. Install the dependencies for Terraform. **Note:** these configuration files are written for `v 0.11.x` and will not work with `v 0.12.x` Terraform installations and rewriting for that spec is not in the immediate roadmap.
+1. Install the dependencies for Terraform.
 
 ```bash
-wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-unzip terraform_0.11.14_linux_amd64.zip
+wget https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_linux_amd64.zip
+unzip terraform_0.14.4_linux_amd64.zip
 sudo mv terraform /usr/local/bin/
 terraform --version
 ```

--- a/terraform-config-files/electric_eye.tf
+++ b/terraform-config-files/electric_eye.tf
@@ -419,7 +419,7 @@ resource "aws_cloudwatch_event_target" "Electric_Eye_Scheduled_Scans" {
       platform_version    = "LATEST"
       network_configuration {
         subnets         = [element(aws_subnet.Electric_Eye_Public_Subnets[*].id, 0)]
-        security_groups = ["${aws_security_group.Electric_Eye_Sec_Group.id}"]
+        security_groups = [aws_security_group.Electric_Eye_Sec_Group.id]
     }
   }
 }

--- a/terraform-config-files/network.tf
+++ b/terraform-config-files/network.tf
@@ -62,7 +62,7 @@ resource "aws_vpc_endpoint" "Electric_Eye_Interface_Interface_ECR-DKR" {
   service_name        = "com.amazonaws.${var.AWS_Region}.ecr.dkr"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = aws_subnet.Electric_Eye_Public_Subnets[*].id
-  security_group_ids  = ["${aws_security_group.Electric_Eye_Sec_Group.id}"]
+  security_group_ids  = [aws_security_group.Electric_Eye_Sec_Group.id]
   private_dns_enabled = true
   tags = {
       Name = "${var.Electric_Eye_VPC_Name_Tag}-ECR-DKR-Endpoint"

--- a/terraform-config-files/provider.tf
+++ b/terraform-config-files/provider.tf
@@ -14,5 +14,5 @@
 # If not, see https://github.com/jonrau1/ElectricEye/blob/master/LICENSE.
 
 provider "aws" {
-  region = "${var.AWS_Region}"
+  region = var.AWS_Region
 }


### PR DESCRIPTION
Terraform config files had been updated several months ago to use 0.12+.  The documentation did not take this update into account and following the instructions caused errors.  Updated the documentation to use the latest version of Terraform instead of 0.11.  

Removed interpolation-only expressions from Terraform config files.  These statements were throwing "Interpolation-only expressions are deprecated" warnings when using later versions of Terraform.