### PR TITLE
Fixing duplicate finding id check name

### DIFF
--- a/eeauditor/auditors/aws/AMI_Auditor.py
+++ b/eeauditor/auditors/aws/AMI_Auditor.py
@@ -184,7 +184,7 @@ def encrypted_ami_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
             if encryptionCheck == "False":
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": amiArn + "/public-ami",
+                    "Id": amiArn + "/encrypted-ami",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": amiArn,
                     "AwsAccountId": awsAccountId,
@@ -240,7 +240,7 @@ def encrypted_ami_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
             else:
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": amiArn + "/public-ami",
+                    "Id": amiArn + "/encrypted-ami",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": amiArn,
                     "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Amazon_AppStream_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_AppStream_Auditor.py
@@ -383,7 +383,7 @@ def userpool_auth_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
         if userAuthType != "SAML":
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userArn + "/appstream-compromised-user",
+                "Id": userArn + "/appstream-userpool-auth-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userArn,
                 "AwsAccountId": awsAccountId,
@@ -442,7 +442,7 @@ def userpool_auth_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userArn + "/appstream-compromised-user",
+                "Id": userArn + "/appstream-userpool-auth-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userArn,
                 "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Amazon_EC2_Image_Builder_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_EC2_Image_Builder_Auditor.py
@@ -155,7 +155,7 @@ def imagebuilder_ebs_encryption_check(cache: dict, awsAccountId: str, awsRegion:
         if ebs_encryption == True:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": recipeArn + "/imagebuilder-pipeline-tests-enabled-check",
+                "Id": recipeArn + "/imagebuilder-ebs-encryption-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": recipeArn,
                 "AwsAccountId": awsAccountId,
@@ -206,7 +206,7 @@ def imagebuilder_ebs_encryption_check(cache: dict, awsAccountId: str, awsRegion:
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": recipeArn + "/imagebuilder-pipeline-tests-enabled-check",
+                "Id": recipeArn + "/imagebuilder-ebs-encryption-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": recipeArn,
                 "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Amazon_EC2_Security_Group_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_EC2_Security_Group_Auditor.py
@@ -525,7 +525,7 @@ def security_group_open_dcom_rpc_check(cache: dict, awsAccountId: str, awsRegion
                 if toPort and fromPort == "135" and cidrIpRange == "0.0.0.0/0":
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": sgArn + "/" + ipProtocol + "/security-group-telnet-open-check",
+                        "Id": sgArn + "/" + ipProtocol + "/security-group-rpc-dcom-open-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": sgArn,
                         "AwsAccountId": awsAccountId,
@@ -594,7 +594,7 @@ def security_group_open_dcom_rpc_check(cache: dict, awsAccountId: str, awsRegion
                 if toPort and fromPort == "135" and cidrIpRange != "0.0.0.0/0":
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": sgArn + "/" + ipProtocol + "/security-group-wsrpc-dcom-open-check",
+                        "Id": sgArn + "/" + ipProtocol + "/security-group-rpc-dcom-open-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": sgArn,
                         "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Amazon_Elasticache_Redis_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_Elasticache_Redis_Auditor.py
@@ -196,7 +196,7 @@ def encryption_at_rest_check(cache: dict, awsAccountId: str, awsRegion: str, aws
             if atRestEncryptionCheck == "False":
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": clusterId + "/no-redis-auth-token",
+                    "Id": clusterId + "/no-encryption-at-rest",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": clusterId,
                     "AwsAccountId": awsAccountId,
@@ -249,7 +249,7 @@ def encryption_at_rest_check(cache: dict, awsAccountId: str, awsRegion: str, aws
             else:
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": clusterId + "/no-redis-auth-token",
+                    "Id": clusterId + "/no-encryption-at-rest",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": clusterId,
                     "AwsAccountId": awsAccountId,
@@ -324,7 +324,7 @@ def encryption_in_transit_check(cache: dict, awsAccountId: str, awsRegion: str, 
             if inTransitEncryptionCheck == "False":
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": clusterId + "/no-redis-auth-token",
+                    "Id": clusterId + "/no-encryption-in-transit",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": clusterId,
                     "AwsAccountId": awsAccountId,
@@ -382,7 +382,7 @@ def encryption_in_transit_check(cache: dict, awsAccountId: str, awsRegion: str, 
             else:
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": clusterId + "/no-redis-auth-token",
+                    "Id": clusterId + "/no-encryption-in-transit",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": clusterId,
                     "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Shodan_Auditor.py
+++ b/eeauditor/auditors/aws/Shodan_Auditor.py
@@ -1276,7 +1276,7 @@ else:
                         # this is a passing check
                         finding = {
                             "SchemaVersion": "2018-10-08",
-                            "Id": gaxArn + "/" + gaxDns + "/cloudfront-shodan-index-check",
+                            "Id": gaxArn + "/" + gaxDns + "/global-accelerator-shodan-check",
                             "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                             "GeneratorId": gaxArn,
                             "AwsAccountId": awsAccountId,
@@ -1330,7 +1330,7 @@ else:
                     else:
                         finding = {
                             "SchemaVersion": "2018-10-08",
-                            "Id": gaxArn + "/" + gaxDns + "/cloudfront-shodan-index-check",
+                            "Id": gaxArn + "/" + gaxDns + "/global-accelerator-shodan-check",
                             "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                             "GeneratorId": gaxArn,
                             "AwsAccountId": awsAccountId,


### PR DESCRIPTION
**Issue**:
In some auditors, the policy check name part in 'Id' is same in two different functions causing security hub to show only 1 finding even if both functions reported one each.
**Changes made**:
changed duplicate finding check name part in 'Id' according to the function name to keep it unique in security hub.