### PR TITLE
Minor check logic changes

### DIFF
--- a/eeauditor/auditors/aws/AWS_ACM_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_ACM_Auditor.py
@@ -21,7 +21,6 @@
 import boto3
 import datetime
 from check_register import CheckRegister
-import multiprocessing
 
 registry = CheckRegister()
 
@@ -199,9 +198,9 @@ def certificate_in_use_check(cache: dict, awsAccountId: str, awsRegion: str, aws
         cSerial = str(cert['Serial'])
         cStatus = str(cert['Status'])
         cKeyAlgo = str(cert['KeyAlgorithm'])
-        useLen = str(len(cert["InUseBy"]))
+        useLen = len(cert["InUseBy"])
         # this is a failing check
-        if useLen == '0':
+        if useLen == 0:
             finding = {
                 "SchemaVersion": "2018-10-08",
                 "Id": carn + "/acm-cert-in-use-check",

--- a/eeauditor/auditors/aws/Amazon_EC2_Security_Group_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_EC2_Security_Group_Auditor.py
@@ -187,18 +187,12 @@ def security_group_open_ftp_check(cache: dict, awsAccountId: str, awsRegion: str
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -346,18 +340,12 @@ def security_group_open_telnet_check(cache: dict, awsAccountId: str, awsRegion: 
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -505,18 +493,12 @@ def security_group_open_dcom_rpc_check(cache: dict, awsAccountId: str, awsRegion
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -680,18 +662,12 @@ def security_group_open_smb_check(cache: dict, awsAccountId: str, awsRegion: str
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -867,18 +843,12 @@ def security_group_open_mssql_check(cache: dict, awsAccountId: str, awsRegion: s
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -1066,18 +1036,12 @@ def security_group_open_oracle_check(cache: dict, awsAccountId: str, awsRegion: 
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -1225,18 +1189,12 @@ def security_group_open_mysql_mariadb_check(cache: dict, awsAccountId: str, awsR
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -1390,18 +1348,12 @@ def security_group_open_rdp_check(cache: dict, awsAccountId: str, awsRegion: str
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -1577,18 +1529,12 @@ def security_group_open_postgresql_check(cache: dict, awsAccountId: str, awsRegi
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -1736,18 +1682,12 @@ def security_group_open_kibana_check(cache: dict, awsAccountId: str, awsRegion: 
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -1923,18 +1863,12 @@ def security_group_open_redis_check(cache: dict, awsAccountId: str, awsRegion: s
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -2110,18 +2044,12 @@ def security_group_open_splunkd_check(cache: dict, awsAccountId: str, awsRegion:
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -2297,18 +2225,12 @@ def security_group_open_elasticsearch1_check(cache: dict, awsAccountId: str, aws
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -2462,18 +2384,12 @@ def security_group_open_elasticsearch2_check(cache: dict, awsAccountId: str, aws
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -2627,18 +2543,12 @@ def security_group_open_memcached_check(cache: dict, awsAccountId: str, awsRegio
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -2824,18 +2734,12 @@ def security_group_open_redshift_check(cache: dict, awsAccountId: str, awsRegion
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -2983,18 +2887,12 @@ def security_group_open_documentdb_check(cache: dict, awsAccountId: str, awsRegi
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -3142,18 +3040,12 @@ def security_group_open_cassandra_check(cache: dict, awsAccountId: str, awsRegio
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -3301,18 +3193,12 @@ def security_group_open_kafka_check(cache: dict, awsAccountId: str, awsRegion: s
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -3460,18 +3346,12 @@ def security_group_open_nfs_check(cache: dict, awsAccountId: str, awsRegion: str
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -3619,18 +3499,12 @@ def security_group_open_rsync_check(cache: dict, awsAccountId: str, awsRegion: s
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -3778,18 +3652,12 @@ def security_group_open_tftp_check(cache: dict, awsAccountId: str, awsRegion: st
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:
@@ -3937,18 +3805,12 @@ def security_group_open_docker_check(cache: dict, awsAccountId: str, awsRegion: 
         for permissions in secgroup["IpPermissions"]:
             try:
                 fromPort = str(permissions["FromPort"])
-            except Exception as e:
-                if str(e) == "'FromPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 toPort = str(permissions["ToPort"])
-            except Exception as e:
-                if str(e) == "'ToPort'":
-                    continue
-                else:
-                    print(e)
+            except KeyError:
+                continue
             try:
                 ipProtocol = str(permissions["IpProtocol"])
             except Exception as e:

--- a/eeauditor/auditors/aws/Shodan_Auditor.py
+++ b/eeauditor/auditors/aws/Shodan_Auditor.py
@@ -39,13 +39,10 @@ cloudfront = boto3.client("cloudfront")
 
 try:
     apiKeyParam = os.environ["SHODAN_API_KEY_PARAM"]
-except Exception as e:
-    if str(e) == "'SHODAN_API_KEY_PARAM'":
-        apiKeyParam = "placeholder"
-    else:
-        print(e)
+except KeyError:
+    apiKeyParam = "placeholder"
 
-if apiKeyParam == "placeholder":
+if apiKeyParam == "placeholder" or None:
     print("Shodan API Key not supplied, skipping!")
     pass
 # Shodan information for Requests

--- a/eeauditor/processor/outputs/docdb-output.py
+++ b/eeauditor/processor/outputs/docdb-output.py
@@ -33,21 +33,21 @@ class JsonProvider(object):
         # Ensure that the required variables are present
         try:
             mongoUname = os.environ["MONGODB_USERNAME"]
-            if mongoUname == "placeholder":
+            if mongoUname == ("placeholder" or None):
                 print("Missing required MongoDB parameters")
         except KeyError:
             print("Missing required MongoDB parameters")
 
         try:
             mongoHostname = os.environ["MONGODB_HOSTNAME"]
-            if mongoHostname == "placeholder":
+            if mongoHostname == ("placeholder" or None):
                 print("Missing required MongoDB parameters")
         except KeyError:
             print("Missing required MongoDB parameters")
 
         try:
             mongoPwParam = os.environ["MONGODB_PASSWORD_PARAMETER"]
-            if mongoPwParam == "placeholder":
+            if mongoPwParam == ("placeholder" or None):
                 print("Missing required MongoDB parameters")
         except KeyError:
             print("Missing required MongoDB parameters")

--- a/eeauditor/processor/outputs/postgresql.py
+++ b/eeauditor/processor/outputs/postgresql.py
@@ -18,6 +18,7 @@
 #specific language governing permissions and limitations
 #under the License.
 import boto3
+import sys
 import os
 import psycopg2 as psql
 from processor.outputs.output_base import ElectricEyeOutput
@@ -32,48 +33,39 @@ class PostgresProvider(object):
         # Username
         try:
             psqlUsername = os.environ["POSTGRES_USERNAME"]
-        except Exception as e:
-            if str(e) == '"POSTGRES_USERNAME"':
-                psqlUsername = "placeholder"
-            else:
-                print(e)
+        except KeyError:
+            psqlUsername = "placeholder"
         # DB Name
         try:
             eePsqlDbName = os.environ["ELECTRICEYE_POSTGRESQL_DB_NAME"]
-        except Exception as e:
-            if str(e) == '"ELECTRICEYE_POSTGRESQL_DB_NAME"':
-                eePsqlDbName = "placeholder"
-            else:
-                print(e)
+        except KeyError:
+            eePsqlDbName = "placeholder"
         # DB Endpoint
         try:
             dbEndpoint = os.environ["POSTGRES_DB_ENDPOINT"]
-        except Exception as e:
-            if str(e) == '"POSTGRES_DB_ENDPOINT"':
-                dbEndpoint = "placeholder"
-            else:
-                print(e)
+        except KeyError:
+            dbEndpoint = "placeholder"
         # DB Port
         try:
             dbPort = os.environ["POSTGRES_DB_PORT"]
-        except Exception as e:
-            if str(e) == '"POSTGRES_DB_PORT"':
-                dbPort = "placeholder"
-            else:
-                print(e)
+        except KeyError:
+            dbPort = "placeholder"
         # Secret Parameter
         try:
             psqlRdsPwSsmParamName = os.environ["POSTGRES_PASSWORD_SSM_PARAM_NAME"]
-        except Exception as e:
-            if str(e) == '"POSTGRES_PASSWORD_SSM_PARAM_NAME"':
-                psqlRdsPwSsmParamName = "placeholder"
-            else:
-                print(e)
+        except KeyError:
+            psqlRdsPwSsmParamName = "placeholder"
         
 
-        if (psqlUsername or eePsqlDbName or dbEndpoint or dbPort or psqlRdsPwSsmParamName) == "placeholder":
+        if (
+            psqlUsername or 
+            eePsqlDbName or 
+            dbEndpoint or 
+            dbPort or 
+            psqlRdsPwSsmParamName
+        ) == ("placeholder" or None):
             print('Either the required RDS Information was not provided, or the "placeholder" values were kept')
-            exit(2)
+            sys.exit(2)
         else:
             # Retrieve and Decrypt DB PW from SSM
             psqlDbPw = ssm.get_parameter(Name=psqlRdsPwSsmParamName, WithDecryption=True)["Parameter"]["Value"]


### PR DESCRIPTION
- Improved Error Handling for optional check Env Vars (Shodan, PostgreSQL, DocumentDB/MongoDB, DisruptOps/FireMon)
- Improved cert usage check for ACM using integer check on `len()`
- Fixed erroneous failures on EC2 SSM Check for Latest SSM Agent, this is only supported for Linux instances as per AWS Support
- Improved error handling and list comprehensions within EC2 SSM Checks
- Improved error handling and list comprehension for EKS Logging checks
- Fixed Exception handling for EKS Envelope Encryption
- Improved readability and Exception handling for all Security Group checks
- Small changes to DisruptOps output
- Removing erroneously imported modules in several Auditors