### PR TITLE
Autoscaling, Cloudfront ASM, Cloudfront Auditor Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ In this stage we will use the console the manually run the ElectricEye ECS task,
 
 ## Supported Services and Checks
 
-These are the following services and checks perform by each Auditor. There are currently **450** checks supported across **91** AWS services / components using **71** Auditors. 
+These are the following services and checks perform by each Auditor. There are currently **456** checks supported across **91** AWS services / components using **71** Auditors. 
 
 There are currently **62** supported response and remediation Playbooks with coverage across **32** AWS services / components supported by [ElectricEye-Response](https://github.com/jonrau1/ElectricEye/blob/master/add-ons/electriceye-response).
 
@@ -519,14 +519,20 @@ There are currently **62** supported response and remediation Playbooks with cov
 | Amazon_Autoscaling_Auditor.py | Autoscaling groups | Do ASGs protect instances from scale-in |
 | Amazon_Autoscaling_Auditor.py | Autoscaling groups | Do ASGs with ELB or Target Groups use ELB health checks |
 | Amazon_Autoscaling_Auditor.py | Autoscaling groups | Do ASGs use at least half or more of a Region's open AZs |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have trusted signers with key pairs |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have Origin Shield enabled |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have Geo Restriction enabled |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have Default Viewer Certificate |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have Field-Level Encryption enabled |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have WAF enabled |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution use Default TLS |
-| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution use Custom Origin TLS |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros with trusted signers use key pairs |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distro origins have Origin Shield enabled |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros use the default viewer certificate |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros have Georestriction enabled |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros have Field-Level Encryption enabled |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros have WAF enabled |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros enforce Default Viewer TLS 1.2 |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros enforce Custom Origin TLS 1.2 |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros enforce Custom Origin HTTPS-only connections |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros enforce Default Viewer HTTPS with SNI |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros have logging enabled |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros have default root objects |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros enforce Default Viewer HTTPS-only connections |
+| Amazon_CloudFront_Auditor.py | CloudFront Distribution | Do distros enforce S3 Origin Object Access Identity |
 | Amazon_CloudSearch_Auditor.py | CloudSearch Domain | Do Domains enforce HTTPS-only |
 | Amazon_CloudSearch_Auditor.py | CloudSearch Domain | Do Domains use TLS 1.2 |
 | Amazon_CognitoIdP_Auditor.py | Cognito Identity Pool | Does the Password policy comply with AWS CIS Foundations Benchmark |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Logo?!](./screenshots/EE-LogoLarge.png)
 
-Continuously monitor your AWS services for configurations that can lead to degradation of confidentiality, integrity or availability. All results can be exported to Security Hub, JSON, CSV, Databases, and more for further aggregation and analysis. 
+Continuously monitor your AWS attack surface and evaluate services for configurations that can lead to degradation of confidentiality, integrity or availability. All results can be exported to Security Hub, JSON, CSV, Databases, and more for further aggregation and analysis. 
 
 ***Up here in space***<br/>
 ***I'm looking down on you***<br/>
@@ -16,6 +16,7 @@ Continuously monitor your AWS services for configurations that can lead to degra
 - [Description](#description)
 - [Solution Architecture](#solution-architecture)
 - [Running locally](#running-locally)
+  - [Attack Surface Monitoring Only](#attack-surface-monitoring-only)
   - [ElectricEye and Custom Outputs](#electriceye-and-custom-outputs)
 - [Setting Up on Fargate](#setting-up-electriceye-on-fargate)
   - [Solution Architecture for Fargate](#aws-fargate-solution-architecture)
@@ -40,7 +41,7 @@ Continuously monitor your AWS services for configurations that can lead to degra
 
 ## Synopsis
 
-- **430+ security & AWS best practice detections** including services not covered by Security Hub/Config (MemoryDB, Cognito, DocDB, Amazon Managed Blockchain, etc.), all findings are **aligned to NIST CSF, NIST 800-53, AICPA's TSCs, ISO 27001:2013 and MITRE ATT&CK**.
+- **450+ security & AWS best practice detections** including services not covered by Security Hub/Config (MemoryDB, Cognito, DocDB, Amazon Managed Blockchain, etc.), all findings are **aligned to NIST CSF, NIST 800-53, AICPA's TSCs, ISO 27001:2013 and MITRE ATT&CK Techniques**.
 
 - Provides basic **Attack Surface Management (ASM)** capabilities, checking for **more than 20 highly dangerous** services running on publicly reachable assets that adversaries can potentially exploit.
 
@@ -52,11 +53,13 @@ Continuously monitor your AWS services for configurations that can lead to degra
 
 ## Description
 
-ElectricEye is a Python-native CLI framework that controls individual Python scripts (affectionately called **Auditors**) which align to a specific AWS service or resource (such as an EC2 Security Group, or Systems Manager Managed Instance) that contain one or more **Checks**. Checks (continuously) monitor your AWS infrastructure looking for configurations related to confidentiality, integrity and availability that do not align with AWS best practices. By default, the output of these checks are formatted using the [AWS Security Finding Format](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) (ASFF) and sent to AWS Security Hub but can be sent to many other locations.
+ElectricEye is a Python-native CLI framework that controls individual Python scripts (affectionately called **Auditors**) which align to a specific AWS service or resource (such as an EC2 Security Group, or Systems Manager Managed Instance) that contain one or more **Checks**. Checks (continuously) monitor your AWS attack surface and evaluate services for configurations that can lead to degradation of confidentiality, integrity or availability. By default, the output of these checks are formatted using the [AWS Security Finding Format](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) (ASFF) and sent to AWS Security Hub but can be sent to many other locations.
 
 As of **30 MARCH 2022** ElectricEye now supports Attack Surface Management (ASM) capabilities, showing you potentially dangerous and exploitable services running on publicly reachable assets such as EC2 Instances and Amazon Elastic Load Balancing (ELB) Application Load Balancers (ALB).
 
-ElectricEye is extensible, however, and can output to JSON, CSV, PostgreSQL, MongoDB/AWS DocumentDB, and other locations and formats. All Checks within ElectricEye are also mapped against popular security framework controls such as the AICPA's Trust Service Criteria (TSCs), NIST 800-53 Rev 5, the NIST Cyber Security Framework (CSF), and ISO/IEC 27001:2013. Additionally, ElectricEye comes with several add-on modules to extend the core model which provides dozens of detection-based controls. ElectricEye-Response provides a multi-account response and remediation platform (also known as SOAR), ElectricEye-ChatOps integrates with Slack/Pagerduty/Microsoft Teams, and ElectricEye-Reports integrates with QuickSight. All add-ons are supported by both CloudFormation and Terraform and can also be used independently of the core module itself.
+ElectricEye is extensible, however, and can output to JSON, CSV, PostgreSQL, MongoDB/AWS DocumentDB, and other locations and formats. All Checks within ElectricEye are also mapped against popular security framework controls such as the AICPA's Trust Service Criteria (TSCs), NIST 800-53 Rev 5, the NIST Cyber Security Framework (CSF), ISO/IEC 27001:2013 and the ASM Checks are mapped to MITRE ATT&CK Techniques.
+
+Additionally, ElectricEye comes with several add-on modules to extend the core model which provides dozens of detection-based controls. ElectricEye-Response provides a multi-account response and remediation platform (also known as SOAR), ElectricEye-ChatOps integrates with Slack/Pagerduty/Microsoft Teams, and ElectricEye-Reports integrates with QuickSight. All add-ons are supported by both CloudFormation and Terraform and can also be used independently of the core module itself.
 
 Numerous personas can make effective usage of ElectricEye such as: Security Operations (SecOps), DevOps, DevSecOps, IT Audit, Governance/Risk/Compliance (GRC) Analysts, Enterprise Architects, Security Architects, Cloud Center of Excellence (CCOE) members, Software Development Engineers (SDEs) using Cloud-native services, Red Teamers, Purple Teamers, and Security Engineering. That said, ElectricEye can also serve as an important assurance tool or educational tool for nearly any persona who works with or is learning the AWS Cloud.
 
@@ -131,6 +134,14 @@ You can get a full name of the auditors (as well as their checks within comments
 
 ```bash
 python3 eeauditor/controller.py --list-checks
+```
+
+### Attack Surface Monitoring Only
+
+If you only wanted to run Attack Surface Monitoring checks use the following command which show an example of outputting the ASM checks into a JSON file for consumption into SIEM or BI tools.
+
+```bash
+python3 eeauditor/controller.py -a ElectricEye_AttackSurface_Auditor -o json_normalized --output-file ElectricASM
 ```
 
 ### ElectricEye and Custom Outputs
@@ -491,7 +502,7 @@ In this stage we will use the console the manually run the ElectricEye ECS task,
 
 ## Supported Services and Checks
 
-These are the following services and checks perform by each Auditor. There are currently **456** checks supported across **91** AWS services / components using **71** Auditors. 
+These are the following services and checks perform by each Auditor. There are currently **481** checks supported across **91** AWS services / components using **71** Auditors. 
 
 There are currently **62** supported response and remediation Playbooks with coverage across **32** AWS services / components supported by [ElectricEye-Response](https://github.com/jonrau1/ElectricEye/blob/master/add-ons/electriceye-response).
 
@@ -946,6 +957,31 @@ There are currently **62** supported response and remediation Playbooks with cov
 | ElectricEye_AttackSurface_Auditor.py | Elastic IP | Is a MongoDB/DocDB service publicly accessible |
 | ElectricEye_AttackSurface_Auditor.py | Elastic IP | Is a Rabbit/AmazonMQ service publicly accessible |
 | ElectricEye_AttackSurface_Auditor.py | Elastic IP | Is a SparkUI service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a FTP service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a SSH service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Telnet service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a SMTP service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a HTTP service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a POP3 service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Win NetBIOS service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a SMB service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a RDP service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a MSSQL service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a MySQL/MariaDB service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a NFS service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Docker API service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a OracleDB service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a PostgreSQL service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Kibana service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a VMWARE ESXi service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a HTTP Proxy service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a SplunkD service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Kubernetes API Server service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Redis service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Kafka service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a MongoDB/DocDB service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a Rabbit/AmazonMQ service publicly accessible |
+| ElectricEye_AttackSurface_Auditor.py | CloudFront Distribution | Is a SparkUI service publicly accessible |
 | Secrets_Auditor.py | CodeBuild project | Do CodeBuild projects have secrets in plaintext env vars |
 | Secrets_Auditor.py | CloudFormation Stack | Do CloudFormation Stacks have secrets in parameters |
 | Secrets_Auditor.py | ECS Task Definition | Do ECS Task Definitions have secrets in env vars |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Continuously monitor your AWS services for configurations that can lead to degra
 
 ## Synopsis
 
-- **400+ security & AWS best practice detections** including services not covered by Security Hub/Config (MemoryDB, Cognito, DocDB, Amazon Managed Blockchain, etc.), all findings are **aligned to NIST CSF, NIST 800-53, AICPA's TSCs and ISO 27001:2013**.
+- **430+ security & AWS best practice detections** including services not covered by Security Hub/Config (MemoryDB, Cognito, DocDB, Amazon Managed Blockchain, etc.), all findings are **aligned to NIST CSF, NIST 800-53, AICPA's TSCs, ISO 27001:2013 and MITRE ATT&CK**.
 
 - Provides basic **Attack Surface Management (ASM)** capabilities, checking for **more than 20 highly dangerous** services running on publicly reachable assets that adversaries can potentially exploit.
 
@@ -52,7 +52,9 @@ Continuously monitor your AWS services for configurations that can lead to degra
 
 ## Description
 
-ElectricEye is a Python-native CLI framework that controls individual Python scripts (affectionately called **Auditors**) which align to a specific AWS service or resource (such as an EC2 Security Group, or Systems Manager Managed Instance) that contain one or more **Checks**. Checks (continuously) monitor your AWS infrastructure looking for configurations related to confidentiality, integrity and availability that do not align with AWS best practices. By default, the output of these checks are formatted using the [AWS Security Finding Format](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) (ASFF) and sent to AWS Security Hub but can be sent to many other locations. As of **30 MARCH 2022** ElectricEye now supports Attack Surface Management (ASM) capabilities, showing you potentially dangerous and exploitable services running on publicly reachable assets such as EC2 Instances and Amazon Elastic Load Balancing (ELB) Application Load Balancers (ALB). 
+ElectricEye is a Python-native CLI framework that controls individual Python scripts (affectionately called **Auditors**) which align to a specific AWS service or resource (such as an EC2 Security Group, or Systems Manager Managed Instance) that contain one or more **Checks**. Checks (continuously) monitor your AWS infrastructure looking for configurations related to confidentiality, integrity and availability that do not align with AWS best practices. By default, the output of these checks are formatted using the [AWS Security Finding Format](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) (ASFF) and sent to AWS Security Hub but can be sent to many other locations.
+
+As of **30 MARCH 2022** ElectricEye now supports Attack Surface Management (ASM) capabilities, showing you potentially dangerous and exploitable services running on publicly reachable assets such as EC2 Instances and Amazon Elastic Load Balancing (ELB) Application Load Balancers (ALB).
 
 ElectricEye is extensible, however, and can output to JSON, CSV, PostgreSQL, MongoDB/AWS DocumentDB, and other locations and formats. All Checks within ElectricEye are also mapped against popular security framework controls such as the AICPA's Trust Service Criteria (TSCs), NIST 800-53 Rev 5, the NIST Cyber Security Framework (CSF), and ISO/IEC 27001:2013. Additionally, ElectricEye comes with several add-on modules to extend the core model which provides dozens of detection-based controls. ElectricEye-Response provides a multi-account response and remediation platform (also known as SOAR), ElectricEye-ChatOps integrates with Slack/Pagerduty/Microsoft Teams, and ElectricEye-Reports integrates with QuickSight. All add-ons are supported by both CloudFormation and Terraform and can also be used independently of the core module itself.
 
@@ -489,7 +491,7 @@ In this stage we will use the console the manually run the ElectricEye ECS task,
 
 ## Supported Services and Checks
 
-These are the following services and checks perform by each Auditor. There are currently **447** checks supported across **90** AWS services / components using **70** Auditors. 
+These are the following services and checks perform by each Auditor. There are currently **450** checks supported across **91** AWS services / components using **71** Auditors. 
 
 There are currently **62** supported response and remediation Playbooks with coverage across **32** AWS services / components supported by [ElectricEye-Response](https://github.com/jonrau1/ElectricEye/blob/master/add-ons/electriceye-response).
 
@@ -514,6 +516,9 @@ There are currently **62** supported response and remediation Playbooks with cov
 | Amazon_AppStream_Auditor.py | AppStream 2.0 (Images) | Are Images Public |
 | Amazon_AppStream_Auditor.py | AppStream 2.0 (Users) | Are users reported as Compromised |
 | Amazon_AppStream_Auditor.py | AppStream 2.0 (Users) | Do users use SAML authentication |
+| Amazon_Autoscaling_Auditor.py | Autoscaling groups | Do ASGs protect instances from scale-in |
+| Amazon_Autoscaling_Auditor.py | Autoscaling groups | Do ASGs with ELB or Target Groups use ELB health checks |
+| Amazon_Autoscaling_Auditor.py | Autoscaling groups | Do ASGs use at least half or more of a Region's open AZs |
 | Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have trusted signers with key pairs |
 | Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have Origin Shield enabled |
 | Amazon_CloudFront_Auditor.py | CloudFront Distribution | Does distribution have Geo Restriction enabled |

--- a/cloudformation/ElectricEye_CFN.yaml
+++ b/cloudformation/ElectricEye_CFN.yaml
@@ -238,6 +238,7 @@ Resources:
                   - appstream:DescribeFleets
                   - appstream:DescribeImages
                   - appstream:DescribeUsers
+                  - autoscaling:DescribeAutoScalingGroups
                   - backup:DescribeProtectedResource
                   - cassandra:Select
                   - cloudformation:DescribeStacks

--- a/eeauditor/auditors/aws/AWS_Global_Accelerator_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_Global_Accelerator_Auditor.py
@@ -104,11 +104,11 @@ def unhealthy_endpoint_group_check(cache: dict, awsAccountId: str, awsRegion: st
                                         "AICPA TSC CC6.1",
                                         "ISO 27001:2013 A.8.1.1",
                                         "ISO 27001:2013 A.8.1.2",
-                                        "ISO 27001:2013 A.12.5.1",
-                                    ],
+                                        "ISO 27001:2013 A.12.5.1"
+                                    ]
                                 },
                                 "Workflow": {"Status": "RESOLVED"},
-                                "RecordState": "ARCHIVED",
+                                "RecordState": "ARCHIVED"
                             }
                             yield finding
                         else:
@@ -155,11 +155,11 @@ def unhealthy_endpoint_group_check(cache: dict, awsAccountId: str, awsRegion: st
                                         "AICPA TSC CC6.1",
                                         "ISO 27001:2013 A.8.1.1",
                                         "ISO 27001:2013 A.8.1.2",
-                                        "ISO 27001:2013 A.12.5.1",
-                                    ],
+                                        "ISO 27001:2013 A.12.5.1"
+                                    ]
                                 },
                                 "Workflow": {"Status": "NEW"},
-                                "RecordState": "ACTIVE",
+                                "RecordState": "ACTIVE"
                             }
                             yield finding
 

--- a/eeauditor/auditors/aws/Amazon_Autoscaling_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_Autoscaling_Auditor.py
@@ -1,0 +1,293 @@
+#This file is part of ElectricEye.
+#SPDX-License-Identifier: Apache-2.0
+
+#Licensed to the Apache Software Foundation (ASF) under one
+#or more contributor license agreements.  See the NOTICE file
+#distributed with this work for additional information
+#regarding copyright ownership.  The ASF licenses this file
+#to you under the Apache License, Version 2.0 (the
+#"License"); you may not use this file except in compliance
+#with the License.  You may obtain a copy of the License at
+
+#http://www.apache.org/licenses/LICENSE-2.0
+
+#Unless required by applicable law or agreed to in writing,
+#software distributed under the License is distributed on an
+#"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#KIND, either express or implied.  See the License for the
+#specific language governing permissions and limitations
+#under the License.
+
+import boto3
+import datetime
+from check_register import CheckRegister
+from dateutil.parser import parse
+
+registry = CheckRegister()
+
+autoscaling = boto3.client("autoscaling")
+
+def describe_auto_scaling_groups(cache):
+    response = cache.get("describe_auto_scaling_groups")
+    if response:
+        return response
+    cache["describe_auto_scaling_groups"] = autoscaling.describe_auto_scaling_groups(MaxRecords=100)
+    return cache["describe_auto_scaling_groups"]
+
+@registry.register_check("autoscaling")
+def autoscaling_scale_in_protection_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[Autoscaling.1] Autoscaling Groups should be configured to protect instances from scale-in"""
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for asg in describe_auto_scaling_groups(cache)["AutoScalingGroups"]:
+        asgArn = asg["AutoScalingGroupARN"]
+        asgName = asg["AutoScalingGroupName"]
+        healthCheckType = asg["HealthCheckType"]
+        asgAzs = asg["AvailabilityZones"]
+        # Check specific metadata
+        scaleInProtection = str(asg["NewInstancesProtectedFromScaleIn"])
+        if scaleInProtection == "False":
+            # this is a failing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{asgArn}/asg-instance-scalein-protection-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": asgArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "LOW"},
+                "Confidence": 99,
+                "Title": "[Autoscaling.1] Autoscaling Groups should be configured to protect instances from scale-in",
+                "Description": f"Autoscaling group {asgName} is not configured to protect instances from scale-in. To control whether an Auto Scaling group can terminate a particular instance when scaling in, use instance scale-in protection, Instance scale-in protection starts when the instance state is InService. Scale-in protection can help prevent application instability due to mulitiple scale events, but may also be detrimental due to over-provisioning. Review the remediation section for more information on this configuration.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "To learn more abotu scale-in protection refer to the Using instance scale-in protection section of the Amazon EC2 Auto Scaling User Guide",
+                        "Url": "https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsAutoScalingAutoScalingGroup",
+                        "Id": asgArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsAutoScalingAutoScalingGroup": {
+                                "HealthCheckType": healthCheckType,
+                                "AvailabilityZones": asgAzs
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF ID.BE-5",
+                        "NIST CSF PR.PT-5",
+                        "NIST SP 800-53 CP-2",
+                        "NIST SP 800-53 CP-11",
+                        "NIST SP 800-53 SA-13",
+                        "NIST SP 800-53 SA14",
+                        "AICPA TSC CC3.1",
+                        "AICPA TSC A1.2",
+                        "ISO 27001:2013 A.11.1.4",
+                        "ISO 27001:2013 A.17.1.1",
+                        "ISO 27001:2013 A.17.1.2",
+                        "ISO 27001:2013 A.17.2.1"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        else:
+            # this is a passing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{asgArn}/asg-instance-scalein-protection-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": asgArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[Autoscaling.1] Autoscaling Groups should be configured to protect instances from scale-in",
+                "Description": f"Autoscaling group {asgName} is configured to protect instances from scale-in.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "To learn more abotu scale-in protection refer to the Using instance scale-in protection section of the Amazon EC2 Auto Scaling User Guide",
+                        "Url": "https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsAutoScalingAutoScalingGroup",
+                        "Id": asgArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsAutoScalingAutoScalingGroup": {
+                                "HealthCheckType": healthCheckType,
+                                "AvailabilityZones": asgAzs
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF ID.BE-5",
+                        "NIST CSF PR.PT-5",
+                        "NIST SP 800-53 CP-2",
+                        "NIST SP 800-53 CP-11",
+                        "NIST SP 800-53 SA-13",
+                        "NIST SP 800-53 SA14",
+                        "AICPA TSC CC3.1",
+                        "AICPA TSC A1.2",
+                        "ISO 27001:2013 A.11.1.4",
+                        "ISO 27001:2013 A.17.1.1",
+                        "ISO 27001:2013 A.17.1.2",
+                        "ISO 27001:2013 A.17.2.1"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
+
+@registry.register_check("autoscaling")
+def autoscaling_load_balancer_healthcheck_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[Autoscaling.2] Autoscaling Groups with load balancer targets should use ELB health checks"""
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for asg in describe_auto_scaling_groups(cache)["AutoScalingGroups"]:
+        asgArn = asg["AutoScalingGroupARN"]
+        asgName = asg["AutoScalingGroupName"]
+        healthCheckType = asg["HealthCheckType"]
+        asgAzs = asg["AvailabilityZones"]
+        # Check specific metadata
+        asgLbs = asg["LoadBalancerNames"]
+        asgTgs = asg["TargetGroupARNs"]
+        # If either list is empty it means there are no ELBs or ELBv2s associated with this ASG
+        if not (asgLbs or asgTgs):
+            print(f"{asgName} does not have any LBs or TGs")
+            continue
+        else:
+            if healthCheckType != "ELB":
+                # this is a failing check
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": f"{asgArn}/asg-elb-asgs-elb-healthcheck-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": asgArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "LOW"},
+                    "Confidence": 99,
+                    "Title": "[Autoscaling.2] Autoscaling Groups with load balancer targets should use ELB health checks",
+                    "Description": f"Autoscaling group {asgName} has ELB or ELBv2 Targets but does not use an ELB Health Check. If you attached a load balancer or target group to your Auto Scaling group, you can configure the group to mark an instance as unhealthy when Elastic Load Balancing reports it as unhealthy. If connection draining is enabled for your load balancer, Amazon EC2 Auto Scaling waits for in-flight requests to complete or the maximum timeout to expire, whichever comes first, before terminating instances due to a scaling event or health check replacement. Review the remediation section for more information on this configuration.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "For information about enabling ELB health checks refer to the Add Elastic Load Balancing health checks to an Auto Scaling group section of the Amazon EC2 Auto Scaling User Guide",
+                            "Url": "https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html",
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsAutoScalingAutoScalingGroup",
+                            "Id": asgArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion,
+                            "Details": {
+                                "AwsAutoScalingAutoScalingGroup": {
+                                    "HealthCheckType": healthCheckType,
+                                    "AvailabilityZones": asgAzs
+                                }
+                            }
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "FAILED",
+                        "RelatedRequirements": [
+                            "NIST CSF ID.AM-2",
+                            "NIST SP 800-53 CM-8",
+                            "NIST SP 800-53 PM-5",
+                            "AICPA TSC CC3.2",
+                            "AICPA TSC CC6.1",
+                            "ISO 27001:2013 A.8.1.1",
+                            "ISO 27001:2013 A.8.1.2",
+                            "ISO 27001:2013 A.12.5.1"
+                        ]
+                    },
+                    "Workflow": {"Status": "NEW"},
+                    "RecordState": "ACTIVE"
+                }
+                yield finding
+            else:
+                # this is a passing check
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": f"{asgArn}/asg-elb-asgs-elb-healthcheck-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": asgArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "INFORMATIONAL"},
+                    "Confidence": 99,
+                    "Title": "[Autoscaling.2] Autoscaling Groups with load balancer targets should use ELB health checks",
+                    "Description": f"Autoscaling group {asgName} has ELB or ELBv2 Targets and uses an ELB Health Check.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "For information about enabling ELB health checks refer to the Add Elastic Load Balancing health checks to an Auto Scaling group section of the Amazon EC2 Auto Scaling User Guide",
+                            "Url": "https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html",
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsAutoScalingAutoScalingGroup",
+                            "Id": asgArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion,
+                            "Details": {
+                                "AwsAutoScalingAutoScalingGroup": {
+                                    "HealthCheckType": healthCheckType,
+                                    "AvailabilityZones": asgAzs
+                                }
+                            }
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "PASSED",
+                        "RelatedRequirements": [
+                            "NIST CSF ID.AM-2",
+                            "NIST SP 800-53 CM-8",
+                            "NIST SP 800-53 PM-5",
+                            "AICPA TSC CC3.2",
+                            "AICPA TSC CC6.1",
+                            "ISO 27001:2013 A.8.1.1",
+                            "ISO 27001:2013 A.8.1.2",
+                            "ISO 27001:2013 A.12.5.1"
+                        ]
+                    },
+                    "Workflow": {"Status": "RESOLVED"},
+                    "RecordState": "ARCHIVED"
+                }
+                yield finding
+
+# TODO: Next        

--- a/eeauditor/auditors/aws/Amazon_Autoscaling_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_Autoscaling_Auditor.py
@@ -286,7 +286,7 @@ def autoscaling_load_balancer_healthcheck_check(cache: dict, awsAccountId: str, 
                 yield finding
 
 @registry.register_check("autoscaling")
-def autoscaling_scale_in_protection_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+def autoscaling_high_availability_az_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Autoscaling.3] Autoscaling Groups should use at least half of a Region's Availability Zones"""
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()

--- a/eeauditor/auditors/aws/Amazon_Autoscaling_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_Autoscaling_Auditor.py
@@ -43,7 +43,6 @@ def autoscaling_scale_in_protection_check(cache: dict, awsAccountId: str, awsReg
         asgArn = asg["AutoScalingGroupARN"]
         asgName = asg["AutoScalingGroupName"]
         healthCheckType = asg["HealthCheckType"]
-        asgAzs = asg["AvailabilityZones"]
         # Check specific metadata
         scaleInProtection = str(asg["NewInstancesProtectedFromScaleIn"])
         if scaleInProtection == "False":
@@ -77,8 +76,7 @@ def autoscaling_scale_in_protection_check(cache: dict, awsAccountId: str, awsReg
                         "Region": awsRegion,
                         "Details": {
                             "AwsAutoScalingAutoScalingGroup": {
-                                "HealthCheckType": healthCheckType,
-                                "AvailabilityZones": asgAzs
+                                "HealthCheckType": healthCheckType
                             }
                         }
                     }
@@ -135,8 +133,7 @@ def autoscaling_scale_in_protection_check(cache: dict, awsAccountId: str, awsReg
                         "Region": awsRegion,
                         "Details": {
                             "AwsAutoScalingAutoScalingGroup": {
-                                "HealthCheckType": healthCheckType,
-                                "AvailabilityZones": asgAzs
+                                "HealthCheckType": healthCheckType
                             }
                         }
                     }
@@ -172,7 +169,6 @@ def autoscaling_load_balancer_healthcheck_check(cache: dict, awsAccountId: str, 
         asgArn = asg["AutoScalingGroupARN"]
         asgName = asg["AutoScalingGroupName"]
         healthCheckType = asg["HealthCheckType"]
-        asgAzs = asg["AvailabilityZones"]
         # Check specific metadata
         asgLbs = asg["LoadBalancerNames"]
         asgTgs = asg["TargetGroupARNs"]
@@ -212,8 +208,7 @@ def autoscaling_load_balancer_healthcheck_check(cache: dict, awsAccountId: str, 
                             "Region": awsRegion,
                             "Details": {
                                 "AwsAutoScalingAutoScalingGroup": {
-                                    "HealthCheckType": healthCheckType,
-                                    "AvailabilityZones": asgAzs
+                                    "HealthCheckType": healthCheckType
                                 }
                             }
                         }
@@ -266,8 +261,7 @@ def autoscaling_load_balancer_healthcheck_check(cache: dict, awsAccountId: str, 
                             "Region": awsRegion,
                             "Details": {
                                 "AwsAutoScalingAutoScalingGroup": {
-                                    "HealthCheckType": healthCheckType,
-                                    "AvailabilityZones": asgAzs
+                                    "HealthCheckType": healthCheckType
                                 }
                             }
                         }

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -1702,7 +1702,7 @@ def cloudfront_distro_default_root_object_check(cache: dict, awsAccountId: str, 
                 "Types": [
                     "Software and Configuration Checks/AWS Security Best Practices",
                     "Effects/Data Exposure",
-                    "Sensitive Data Identifications",
+                    "Sensitive Data Identifications"
                 ],
                 "FirstObservedAt": iso8601Time,
                 "CreatedAt": iso8601Time,
@@ -1764,7 +1764,7 @@ def cloudfront_distro_default_root_object_check(cache: dict, awsAccountId: str, 
                 "Types": [
                     "Software and Configuration Checks/AWS Security Best Practices",
                     "Effects/Data Exposure",
-                    "Sensitive Data Identifications",
+                    "Sensitive Data Identifications"
                 ],
                 "FirstObservedAt": iso8601Time,
                 "CreatedAt": iso8601Time,
@@ -1943,4 +1943,228 @@ def cloudfront_default_viewer_https_only_protcol_check(cache: dict, awsAccountId
             }
             yield finding
 
-## TODO: NEXT
+@registry.register_check("cloudfront")
+def cloudfront_s3_origin_oai_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[CloudFront.14] Cloudfront Distributions with S3 Origins should have origin access identity enabled"""
+    # ISO Time
+    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
+    for dist in paginate(cache):
+        distributionId = dist["Id"]
+        distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
+        # Get check specific metadata
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        if not distro["DistributionConfig"]["Origins"]["Items"]:
+            continue
+        else:
+            for orig in distro["DistributionConfig"]["Origins"]["Items"]:
+                originId = orig["Id"]
+                try:
+                    if str(orig["S3OriginConfig"]["OriginAccessIdentity"]) == "":
+                        # this is a failing check
+                        finding = {
+                            "SchemaVersion": "2018-10-08",
+                            "Id": f"{distributionArn}/{originId}/cloudfront-s3-origin-origin-access-identity-check",
+                            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                            "GeneratorId": distributionArn,
+                            "AwsAccountId": awsAccountId,
+                            "Types": [
+                                "Software and Configuration Checks/AWS Security Best Practices",
+                                "Effects/Data Exposure",
+                                "Sensitive Data Identifications",
+                            ],
+                            "FirstObservedAt": iso8601Time,
+                            "CreatedAt": iso8601Time,
+                            "UpdatedAt": iso8601Time,
+                            "Severity": {"Label": "MEDIUM"},
+                            "Confidence": 99,
+                            "Title": "[CloudFront.14] Cloudfront Distributions with S3 Origins should have origin access identity enabled",
+                            "Description": f"CloudFront Origin {originId} for Distribution {distributionId} does not have an origin access identity enabled. CloudFront OAI prevents users from accessing S3 bucket content directly. When users access an S3 bucket directly, they effectively bypass the CloudFront distribution and any permissions that are applied to the underlying S3 bucket content. For more information see the remediation section.",
+                            "Remediation": {
+                                "Recommendation": {
+                                    "Text": "For detailed remediation instructions refer to the Creating a CloudFront OAI and adding it to your distribution section of the Amazon CloudFront Developer Guide",
+                                    "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#private-content-creating-oai",
+                                }
+                            },
+                            "ProductFields": {"Product Name": "ElectricEye"},
+                            "Resources": [
+                                {
+                                    "Type": "AwsCloudFrontDistribution",
+                                    "Id": distributionArn,
+                                    "Partition": awsPartition,
+                                    "Region": awsRegion,
+                                    "Details": {
+                                        "AwsCloudFrontDistribution": {
+                                            "DomainName": domainName,
+                                            "Status": distStatus,
+                                            "Origins": {
+                                                "Items": [
+                                                    {
+                                                        "Id": originId
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "Compliance": {
+                                "Status": "FAILED",
+                                "RelatedRequirements": [
+                                    "NIST CSF PR.AC-3",
+                                    "NIST SP 800-53 AC-1",
+                                    "NIST SP 800-53 AC-17",
+                                    "NIST SP 800-53 AC-19",
+                                    "NIST SP 800-53 AC-20",
+                                    "NIST SP 800-53 SC-15",
+                                    "AICPA TSC CC6.6",
+                                    "ISO 27001:2013 A.6.2.1",
+                                    "ISO 27001:2013 A.6.2.2",
+                                    "ISO 27001:2013 A.11.2.6",
+                                    "ISO 27001:2013 A.13.1.1",
+                                    "ISO 27001:2013 A.13.2.1"
+                                ]
+                            },
+                            "Workflow": {"Status": "NEW"},
+                            "RecordState": "ACTIVE"
+                        }
+                        yield finding
+                    else:
+                        # this is a passing check
+                        finding = {
+                            "SchemaVersion": "2018-10-08",
+                            "Id": f"{distributionArn}/{originId}/cloudfront-s3-origin-origin-access-identity-check",
+                            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                            "GeneratorId": distributionArn,
+                            "AwsAccountId": awsAccountId,
+                            "Types": [
+                                "Software and Configuration Checks/AWS Security Best Practices",
+                                "Effects/Data Exposure",
+                                "Sensitive Data Identifications",
+                            ],
+                            "FirstObservedAt": iso8601Time,
+                            "CreatedAt": iso8601Time,
+                            "UpdatedAt": iso8601Time,
+                            "Severity": {"Label": "INFORMATIONAL"},
+                            "Confidence": 99,
+                            "Title": "[CloudFront.14] Cloudfront Distributions with S3 Origins should have origin access identity enabled",
+                            "Description": f"CloudFront Origin {originId} for Distribution {distributionId} has an origin access identity enabled.",
+                            "Remediation": {
+                                "Recommendation": {
+                                    "Text": "For detailed remediation instructions refer to the Creating a CloudFront OAI and adding it to your distribution section of the Amazon CloudFront Developer Guide",
+                                    "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#private-content-creating-oai",
+                                }
+                            },
+                            "ProductFields": {"Product Name": "ElectricEye"},
+                            "Resources": [
+                                {
+                                    "Type": "AwsCloudFrontDistribution",
+                                    "Id": distributionArn,
+                                    "Partition": awsPartition,
+                                    "Region": awsRegion,
+                                    "Details": {
+                                        "AwsCloudFrontDistribution": {
+                                            "DomainName": domainName,
+                                            "Status": distStatus,
+                                            "Origins": {
+                                                "Items": [
+                                                    {
+                                                        "Id": originId
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "Compliance": {
+                                "Status": "PASSED",
+                                "RelatedRequirements": [
+                                    "NIST CSF PR.AC-3",
+                                    "NIST SP 800-53 AC-1",
+                                    "NIST SP 800-53 AC-17",
+                                    "NIST SP 800-53 AC-19",
+                                    "NIST SP 800-53 AC-20",
+                                    "NIST SP 800-53 SC-15",
+                                    "AICPA TSC CC6.6",
+                                    "ISO 27001:2013 A.6.2.1",
+                                    "ISO 27001:2013 A.6.2.2",
+                                    "ISO 27001:2013 A.11.2.6",
+                                    "ISO 27001:2013 A.13.1.1",
+                                    "ISO 27001:2013 A.13.2.1"
+                                ]
+                            },
+                            "Workflow": {"Status": "RESOLVED"},
+                            "RecordState": "ARCHIVED"
+                        }
+                        yield finding
+                except KeyError:
+                    # this is a passing check
+                    finding = {
+                        "SchemaVersion": "2018-10-08",
+                        "Id": f"{distributionArn}/{originId}/cloudfront-s3-origin-origin-access-identity-check",
+                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                        "GeneratorId": distributionArn,
+                        "AwsAccountId": awsAccountId,
+                        "Types": [
+                            "Software and Configuration Checks/AWS Security Best Practices",
+                            "Effects/Data Exposure",
+                            "Sensitive Data Identifications",
+                        ],
+                        "FirstObservedAt": iso8601Time,
+                        "CreatedAt": iso8601Time,
+                        "UpdatedAt": iso8601Time,
+                        "Severity": {"Label": "INFORMATIONAL"},
+                        "Confidence": 99,
+                        "Title": "[CloudFront.14] Cloudfront Distributions with S3 Origins should have origin access identity enabled",
+                        "Description": f"CloudFront Origin {originId} for Distribution {distributionId} is not an S3 Origin and is thus not in scope for this check.",
+                        "Remediation": {
+                            "Recommendation": {
+                                "Text": "For detailed remediation instructions refer to the Creating a CloudFront OAI and adding it to your distribution section of the Amazon CloudFront Developer Guide",
+                                "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#private-content-creating-oai",
+                            }
+                        },
+                        "ProductFields": {"Product Name": "ElectricEye"},
+                        "Resources": [
+                            {
+                                "Type": "AwsCloudFrontDistribution",
+                                "Id": distributionArn,
+                                "Partition": awsPartition,
+                                "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus,
+                                        "Origins": {
+                                            "Items": [
+                                                {
+                                                    "Id": originId
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "Compliance": {
+                            "Status": "PASSED",
+                            "RelatedRequirements": [
+                                "NIST CSF PR.AC-3",
+                                "NIST SP 800-53 AC-1",
+                                "NIST SP 800-53 AC-17",
+                                "NIST SP 800-53 AC-19",
+                                "NIST SP 800-53 AC-20",
+                                "NIST SP 800-53 SC-15",
+                                "AICPA TSC CC6.6",
+                                "ISO 27001:2013 A.6.2.1",
+                                "ISO 27001:2013 A.6.2.2",
+                                "ISO 27001:2013 A.11.2.6",
+                                "ISO 27001:2013 A.13.1.1",
+                                "ISO 27001:2013 A.13.2.1"
+                            ]
+                        },
+                        "Workflow": {"Status": "RESOLVED"},
+                        "RecordState": "ARCHIVED"
+                    }
+                    yield finding

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -48,6 +48,8 @@ def cloudfront_active_trusted_signers_check(cache: dict, awsAccountId: str, awsR
     for dist in paginate(cache):
         distributionId = dist["Id"]
         distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
         # Get check specific metadata
         distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
         if str(distro["ActiveTrustedSigners"]["Enabled"]) == 'True':
@@ -81,6 +83,12 @@ def cloudfront_active_trusted_signers_check(cache: dict, awsAccountId: str, awsR
                                 "Id": distributionArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus
+                                    }
+                                }
                             }
                         ],
                         "Compliance": {
@@ -130,6 +138,12 @@ def cloudfront_active_trusted_signers_check(cache: dict, awsAccountId: str, awsR
                                 "Id": distributionArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus
+                                    }
+                                }
                             }
                         ],
                         "Compliance": {
@@ -179,6 +193,12 @@ def cloudfront_active_trusted_signers_check(cache: dict, awsAccountId: str, awsR
                         "Id": distributionArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
                     }
                 ],
                 "Compliance": {
@@ -207,6 +227,8 @@ def cloudfront_origin_shield_check(cache: dict, awsAccountId: str, awsRegion: st
     for dist in paginate(cache):
         distributionId = dist["Id"]
         distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
         # Get check specific metadata
         distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
         if not distro["DistributionConfig"]["Origins"]["Items"]:
@@ -243,6 +265,15 @@ def cloudfront_origin_shield_check(cache: dict, awsAccountId: str, awsRegion: st
                                 "Id": distributionArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus,
+                                        "Origins": {
+                                            "Id": originId
+                                        }
+                                    }
+                                }
                             }
                         ],
                         "Compliance": {
@@ -295,6 +326,15 @@ def cloudfront_origin_shield_check(cache: dict, awsAccountId: str, awsRegion: st
                                 "Id": distributionArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus,
+                                        "Origins": {
+                                            "Id": originId
+                                        }
+                                    }
+                                }
                             }
                         ],
                         "Compliance": {

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -46,6 +46,7 @@ def cloudfront_active_trusted_signers_check(cache: dict, awsAccountId: str, awsR
     # ISO Time
     iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
     for dist in paginate(cache):
+        print(dist)
         distributionId = dist["Id"]
         distribution = cloudfront.get_distribution(Id=distributionId)
         try:

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -19,7 +19,7 @@
 #under the License.
 
 import datetime
-import uuid
+import json
 import boto3
 from check_register import CheckRegister
 
@@ -46,963 +46,121 @@ def cloudfront_active_trusted_signers_check(cache: dict, awsAccountId: str, awsR
     # ISO Time
     iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
     for dist in paginate(cache):
-        print(dist)
         distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            activeTrustedSigners = distribution["Distribution"]["ActiveTrustedSigners"]["Enabled"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not activeTrustedSigners:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-active-trusted-signers-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.1] Trusted signers should have key pairs",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has trusted signers without key pairs.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on key pairs for CloudFront trusted signers refer to the Creating CloudFront Key Pairs for Your Trusted Signers section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF ID.AM-2",
-                            "NIST SP 800-53 CM-8",
-                            "NIST SP 800-53 PM-5",
-                            "AICPA TSC CC3.2",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.1.1",
-                            "ISO 27001:2013 A.8.1.2",
-                            "ISO 27001:2013 A.12.5.1",
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-active-trusted-signers-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "INFORMATIONAL"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.1] Trusted signers should have key pairs",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has trusted signers with key pairs.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on key pairs for CloudFront trusted signers refer to the Creating CloudFront Key Pairs for Your Trusted Signers section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF ID.AM-2",
-                            "NIST SP 800-53 CM-8",
-                            "NIST SP 800-53 PM-5",
-                            "AICPA TSC CC3.2",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.1.1",
-                            "ISO 27001:2013 A.8.1.2",
-                            "ISO 27001:2013 A.12.5.1",
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
+        distributionArn = dist["ARN"]
+        # Get deeper details
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        print(json.dumps(distro,indent=4,default=str))
 
-@registry.register_check("cloudfront")
-def cloudfront_origin_shield_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.2] Distributions should have Origin Shield enabled"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            originShield = distribution["Distribution"]["DistributionConfig"]["Origins"]["Items"]["OriginShield"]["Enabled"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not originShield:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-originshield-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.2] Distributions should have Origin Shield enabled",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does not have Origin Shield enabled.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Origin Shield for CloudFront, refer to the Using Amazon CloudFront Origin Shield section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF ID.BE-5",
-                            "NIST CSF PR.PT-5",
-                            "NIST SP 800-53 CP-2",
-                            "NIST SP 800-53 CP-11",
-                            "NIST SP 800-53 SA-13",
-                            "NIST SP 800-53 SA14",
-                            "AICPA TSC CC3.1",
-                            "AICPA TSC A1.2",
-                            "ISO 27001:2013 A.11.1.4",
-                            "ISO 27001:2013 A.17.1.1",
-                            "ISO 27001:2013 A.17.1.2",
-                            "ISO 27001:2013 A.17.2.1",                            
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-origin-shield-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "INFORMATIONAL"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.2] Distributions should have Origin Shield enabled",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has Origin Shield enabled.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Origin Shield for CloudFront, refer to the Using Amazon CloudFront Origin Shield section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF ID.BE-5",
-                            "NIST CSF PR.PT-5",
-                            "NIST SP 800-53 CP-2",
-                            "NIST SP 800-53 CP-11",
-                            "NIST SP 800-53 SA-13",
-                            "NIST SP 800-53 SA14",
-                            "AICPA TSC CC3.1",
-                            "AICPA TSC A1.2",
-                            "ISO 27001:2013 A.11.1.4",
-                            "ISO 27001:2013 A.17.1.1",
-                            "ISO 27001:2013 A.17.1.2",
-                            "ISO 27001:2013 A.17.2.1",
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
 
-@registry.register_check("cloudfront")
-def cloudfront_default_viewer_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.3] Distributions should have a Default Viewer certificate in place"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
         distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            defaultViewer = distribution["Distribution"]["DistributionConfig"]["ViewerCertificate": {"CloudFrontDefaultCertificate": True}]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not defaultViewer:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-defaultviewer-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
+        # Check specific metadata
+        activeTrustedSigners = distribution["Distribution"]["ActiveTrustedSigners"]["Enabled"]
+        distributionArn = distribution["Distribution"]["ARN"]
+        
+        if not activeTrustedSigners:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-active-trusted-signers-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": [
+                    "Software and Configuration Checks/AWS Security Best Practices"
+                ],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "LOW"},
+                "Confidence": 99,
+                "Title": "[CloudFront.1] Trusted signers should have key pairs",
+                "Description": "Distribution "
+                + distributionId
+                + " has trusted signers without key pairs.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on key pairs for CloudFront trusted signers refer to the Creating CloudFront Key Pairs for Your Trusted Signers section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF ID.AM-2",
+                        "NIST SP 800-53 CM-8",
+                        "NIST SP 800-53 PM-5",
+                        "AICPA TSC CC3.2",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.1.1",
+                        "ISO 27001:2013 A.8.1.2",
+                        "ISO 27001:2013 A.12.5.1",
                     ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.3] Distributions should have a Default Viewer certificate in place",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does not have Default Viewer certificate in place.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Default Viewer certificates for CloudFront, refer to the Requiring HTTPS for Communication Between Viewers and CloudFront section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-viewers-to-cloudfront.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE",
+            }
+            yield finding
+        else:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-active-trusted-signers-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": [
+                    "Software and Configuration Checks/AWS Security Best Practices"
+                ],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[CloudFront.1] Trusted signers should have key pairs",
+                "Description": "Distribution "
+                + distributionId
+                + " has trusted signers with key pairs.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on key pairs for CloudFront trusted signers refer to the Creating CloudFront Key Pairs for Your Trusted Signers section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF ID.AM-2",
+                        "NIST SP 800-53 CM-8",
+                        "NIST SP 800-53 PM-5",
+                        "AICPA TSC CC3.2",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.1.1",
+                        "ISO 27001:2013 A.8.1.2",
+                        "ISO 27001:2013 A.12.5.1",
                     ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-defaultviewer-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.3] Distributions should have a Default Viewer certificate in place",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has Default Viewer certificate in place.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Default Viewer certificates for CloudFront, refer to the Requiring HTTPS for Communication Between Viewers and CloudFront section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-viewers-to-cloudfront.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED",
+            }
+            yield finding
 
-@registry.register_check("cloudfront")
-def cloudfront_georestriction_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.4] Distributions should have Geo Ristriction in place"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            geoRestriction = distribution["Distribution"]["DistributionConfig"]["Restrictions"]["GeoRestriction"]["RestrictionType"]["CloudFrontDefaultCertificate": "blacklist"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not geoRestriction:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-geo-restriction-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.4] Distributions should have Geo Ristriction in place",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does not have Geo Restriction in place.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Geo Restriction for CloudFront, refer to the Restricting the Geographic Distribution of Your Content section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/georestrictions.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-geo-restriction-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.4] Distributions should have Geo Ristriction in place",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has Geo Restriction in place.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Geo Restriction for CloudFront, refer to the Restricting the Geographic Distribution of Your Content section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/georestrictions.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
 
-@registry.register_check("cloudfront")
-def cloudfront_field_level_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.5] Distributions should have Field-Level Encryption in place"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            fieldLevelEncryption = distribution["Distribution"]["DistributionConfig"]["DefaultCacheBehavior"]["FieldLevelEncryptionId": "string"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not fieldLevelEncryption:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-field-level-encryption-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.5] Distributions should have Field-Level Encryption in place",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does not have Field Level Encryption in place.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Field-Level Encryption for CloudFront, refer to the Using Field-Level Encryption to Help Protect Sensitive Data section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/field-level-encryption.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-1",
-                            "NIST SP 800-53 MP-8",
-                            "NIST SP 800-53 SC-12",
-                            "NIST SP 800-53 SC-28",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-field-level-encryption-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.5] Distributions should have Field-Level Encryption in place",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does have Field-Level Encryption in place.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Field Level Encryption for CloudFront, refer to the Using Field-Level Encryption to Help Protect Sensitive Data section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/field-level-encryption.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-1",
-                            "NIST SP 800-53 MP-8",
-                            "NIST SP 800-53 SC-12",
-                            "NIST SP 800-53 SC-28",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
 
-@registry.register_check("cloudfront")
-def cloudfront_waf_enabled_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.6] Distributions should have WAF enabled"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            wafEnabled = distribution["Distribution"]["DistributionConfig"]["WebACLId": "string"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not wafEnabled:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-waf-enabled-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.6] Distributions should have WAF enabled",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does not have WAF enabled.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on WAF for CloudFront, refer to the Using AWS WAF to Control Access to Your Content section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-awswaf.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF DE.AE-2",
-                            "NIST SP 800-53 AU-6",
-                            "NIST SP 800-53 CA-7",
-                            "NIST SP 800-53 IR-4",
-                            "NIST SP 800-53 SI-4",
-                            "AICPA TSC CC7.2",
-                            "ISO 27001:2013 A.12.4.1",
-                            "ISO 27001:2013 A.16.1.1",
-                            "ISO 27001:2013 A.16.1.4"
-                        ]
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-waf-enabled-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.6] Distributions should have WAF enabled",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does has WAF enabled.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on WAF for CloudFront, refer to the Using AWS WAF to Control Access to Your Content section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-awswaf.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF DE.AE-2",
-                            "NIST SP 800-53 AU-6",
-                            "NIST SP 800-53 CA-7",
-                            "NIST SP 800-53 IR-4",
-                            "NIST SP 800-53 SI-4",
-                            "AICPA TSC CC7.2",
-                            "ISO 27001:2013 A.12.4.1",
-                            "ISO 27001:2013 A.16.1.1",
-                            "ISO 27001:2013 A.16.1.4",
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
-
-@registry.register_check("cloudfront")
-def cloudfront_default_tls_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.7] Distributions should have Default TLS enabled"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            defaultTls = distribution["Distribution"]["DistributionConfig"]["MinimumProtocolVersion": "TLSv1"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not defaultTls:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-default-tls-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.7] Distributions should have Default TLS enabled",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does not have Default TLS enabled.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Default TLS settings for CloudFront, refer to the Creating, Updating, and Deleting Distributions section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",                            
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-default-tls-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.7] Distributions should have Default TLS enabled",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " does have Default TLS enabled.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Default TLS settings for CloudFront, refer to the Creating, Updating, and Deleting Distributions section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",                            
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
-
-@registry.register_check("cloudfront")
-def cloudfront_custom_origin_tls_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[CloudFront.8] Distributions using Custom Origins should be using TLSv1.2"""
-    # ISO Time
-    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
-    for dist in paginate(cache):
-        distributionId = dist["Id"]
-        distribution = cloudfront.get_distribution(Id=distributionId)
-        try:
-            customOriginTls = distribution["Distribution"]["DistributionConfig"]["Origins"]["Items"]["Origins"]["CustomOriginConfig"]["OriginSslProtocols"]["Items": "TLSv1.2"]
-            distributionArn = distribution["Distribution"]["ARN"]
-            
-            if not customOriginTls:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-custom-origin-tls-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.8] Distributions using Custom Origins should be using TLSv1.2",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has Custom Origins not using TLSv1.2.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Values That You Specify When You Create or Update a Distribution section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",                            
-                        ],
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{distributionArn}/cloudfront-custom-origin-tls-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": distributionArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": [
-                        "Software and Configuration Checks/AWS Security Best Practices"
-                    ],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[CloudFront.8] Distributions using Custom Origins should be using TLSv1.2",
-                    "Description": "Distribution "
-                    + distributionId
-                    + " has Custom Origins using TLSv1.2.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Values That You Specify When You Create or Update a Distribution section of the Amazon CloudFront Developer Guide",
-                            "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsCloudFrontDistribution",
-                            "Id": distributionArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3",                            
-                        ],
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
-                }
-                yield finding
-        except Exception as e:
-            print(e)
+## TODO: NEXT

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -270,7 +270,11 @@ def cloudfront_origin_shield_check(cache: dict, awsAccountId: str, awsRegion: st
                                         "DomainName": domainName,
                                         "Status": distStatus,
                                         "Origins": {
-                                            "Id": originId
+                                            "Items": [
+                                                {
+                                                    "Id": originId
+                                                }
+                                            ]
                                         }
                                     }
                                 }
@@ -331,7 +335,11 @@ def cloudfront_origin_shield_check(cache: dict, awsAccountId: str, awsRegion: st
                                         "DomainName": domainName,
                                         "Status": distStatus,
                                         "Origins": {
-                                            "Id": originId
+                                            "Items": [
+                                                {
+                                                    "Id": originId
+                                                }
+                                            ]
                                         }
                                     }
                                 }

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -564,7 +564,7 @@ def cloudfront_georestriction_check(cache: dict, awsAccountId: str, awsRegion: s
             }
             yield finding
         else:
-            restrictedCountries = str(distro["DistributionConfig"]["Restrictions"]["GeoRestriction"]["Items"])
+            restrictedCountries = str(distro["DistributionConfig"]["Restrictions"]["GeoRestriction"]["Items"]).replace("'","").replace("[","").replace("]","")
             # this is a passing check
             finding = {
                 "SchemaVersion": "2018-10-08",
@@ -579,7 +579,7 @@ def cloudfront_georestriction_check(cache: dict, awsAccountId: str, awsRegion: s
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
                 "Title": "[CloudFront.4] Cloudfront Distributions should have a Georestriction configured",
-                "Description": f"CloudFront Distribution {distributionId} uses a {geoBlockType} Geostrictiction against the following countries {restrictedCountries}.",
+                "Description": f"CloudFront Distribution {distributionId} uses a {geoBlockType} Geostrictiction against the following countries: {restrictedCountries}.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "For more information on Geo Restriction for CloudFront, refer to the Restricting the Geographic Distribution of Your Content section of the Amazon CloudFront Developer Guide",
@@ -621,5 +621,810 @@ def cloudfront_georestriction_check(cache: dict, awsAccountId: str, awsRegion: s
                 "RecordState": "ARCHIVED"
             }
             yield finding
+
+@registry.register_check("cloudfront")
+def cloudfront_field_level_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[CloudFront.5] Cloudfront Distributions should implement Field-Level Encryption in default cache behavior"""
+    # ISO Time
+    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
+    for dist in paginate(cache):
+        distributionId = dist["Id"]
+        distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
+        # Get check specific metadata
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        if str(distro["DistributionConfig"]["DefaultCacheBehavior"]["FieldLevelEncryptionId"]) == "":
+            # this is a failing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-field-level-encryption-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "MEDIUM"},
+                "Confidence": 99,
+                "Title": "[CloudFront.5] Cloudfront Distributions should implement Field-Level Encryption in default cache behavior",
+                "Description": f"CloudFront Distribution {distributionId} does not implement Field-Level Encryption. With Amazon CloudFront, you can enforce secure end-to-end connections to origin servers by using HTTPS. Field-level encryption adds an additional layer of security that lets you protect specific data throughout system processing so that only certain applications can see it. Field-level encryption allows you to enable your users to securely upload sensitive information to your web servers. The sensitive information provided by your users is encrypted at the edge, close to the user, and remains encrypted throughout your entire application stack. This encryption ensures that only applications that need the data—and have the credentials to decrypt it—are able to do so. For more information see the remediation section.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on Field-Level Encryption for CloudFront, refer to the Using Field-Level Encryption to Help Protect Sensitive Data section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/field-level-encryption.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.DS-1",
+                        "NIST SP 800-53 MP-8",
+                        "NIST SP 800-53 SC-12",
+                        "NIST SP 800-53 SC-28",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.2.3"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        else:
+            # this is a passing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-field-level-encryption-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[CloudFront.5] Cloudfront Distributions should implement Field-Level Encryption in default cache behavior",
+                "Description": f"CloudFront Distribution {distributionId} uses Field-Level Encryption.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on Field-Level Encryption for CloudFront, refer to the Using Field-Level Encryption to Help Protect Sensitive Data section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/field-level-encryption.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.DS-1",
+                        "NIST SP 800-53 MP-8",
+                        "NIST SP 800-53 SC-12",
+                        "NIST SP 800-53 SC-28",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.2.3"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
+
+@registry.register_check("cloudfront")
+def cloudfront_waf_enabled_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[CloudFront.6] Cloudfront Distributions should use a Web Application Firewall"""
+    # ISO Time
+    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
+    for dist in paginate(cache):
+        distributionId = dist["Id"]
+        distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
+        # Get check specific metadata
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        if str(distro["DistributionConfig"]["WebACLId"]) == "":
+            # this is a failing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-waf-enabled-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "MEDIUM"},
+                "Confidence": 99,
+                "Title": "[CloudFront.6] Cloudfront Distributions should use a Web Application Firewall",
+                "Description": f"CloudFront Distribution {distributionId} does not use a Web Application Firewall. AWS WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to CloudFront, and lets you control access to your content. Based on conditions that you specify, such as the values of query strings or the IP addresses that requests originate from, CloudFront responds to requests either with the requested content or with an HTTP status code 403 (Forbidden). You can also configure CloudFront to return a custom error page when a request is blocked. For more information see the remediation section.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on WAF for CloudFront, refer to the Using AWS WAF to Control Access to Your Content section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-awswaf.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF DE.AE-2",
+                        "NIST SP 800-53 AU-6",
+                        "NIST SP 800-53 CA-7",
+                        "NIST SP 800-53 IR-4",
+                        "NIST SP 800-53 SI-4",
+                        "AICPA TSC CC7.2",
+                        "ISO 27001:2013 A.12.4.1",
+                        "ISO 27001:2013 A.16.1.1",
+                        "ISO 27001:2013 A.16.1.4"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        else:
+            # this is a passing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-waf-enabled-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[CloudFront.6] Cloudfront Distributions should use a Web Application Firewall",
+                "Description": f"CloudFront Distribution {distributionId} uses a Web Application Firewall.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on WAF for CloudFront, refer to the Using AWS WAF to Control Access to Your Content section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-awswaf.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF DE.AE-2",
+                        "NIST SP 800-53 AU-6",
+                        "NIST SP 800-53 CA-7",
+                        "NIST SP 800-53 IR-4",
+                        "NIST SP 800-53 SI-4",
+                        "AICPA TSC CC7.2",
+                        "ISO 27001:2013 A.12.4.1",
+                        "ISO 27001:2013 A.16.1.1",
+                        "ISO 27001:2013 A.16.1.4"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
+
+@registry.register_check("cloudfront")
+def cloudfront_default_viewer_tls12_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[CloudFront.7] Cloudfront Distributions should enforce TLS 1.2 for the default viewer protocol"""
+    # TLS 1.2 policies
+    compliantMinimumProtocolVersions = [
+        "TLSv1.2_2021",
+        "TLSv1.2_2019",
+        "TLSv1.2_2018"
+    ]
+    # ISO Time
+    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
+    for dist in paginate(cache):
+        distributionId = dist["Id"]
+        distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
+        # Get check specific metadata
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        if str(distro["DistributionConfig"]["ViewerCertificate"]["MinimumProtocolVersion"]) not in compliantMinimumProtocolVersions:
+            # this is a failing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-default-viewer-tls12-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "HIGH"},
+                "Confidence": 99,
+                "Title": "[CloudFront.7] Cloudfront Distributions should enforce TLS 1.2 for the default viewer protocol",
+                "Description": f"CloudFront Distribution {distributionId} does not enforce a compliant TLS 1.2 minimum protocol for default viewer behavior. When you require HTTPS between viewers and your CloudFront distribution, you must choose a security policy, which determines the following settings: The minimum SSL/TLS protocol and ciphers that CloudFront uses to communicate with viewers. TLS 1.2 is more secure than the previous cryptographic protocols such as SSL 2.0, SSL 3.0, TLS 1.0, and TLS 1.1. Essentially, TLS 1.2 keeps data being transferred across the network more secure. For more information see the remediation section.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on Default TLS settings for CloudFront, refer to the Supported protocols and ciphers between viewers and CloudFront section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.DS-2",
+                        "NIST SP 800-53 SC-8",
+                        "NIST SP 800-53 SC-11",
+                        "NIST SP 800-53 SC-12",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.2.3",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1",
+                        "ISO 27001:2013 A.13.2.3",
+                        "ISO 27001:2013 A.14.1.2",
+                        "ISO 27001:2013 A.14.1.3"                    
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        else:
+            # this is a passing check
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{distributionArn}/cloudfront-default-viewer-tls12-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": distributionArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[CloudFront.7] Cloudfront Distributions should enforce TLS 1.2 for the default viewer protocol",
+                "Description": f"CloudFront Distribution {distributionId} enforces a compliant TLS 1.2 minimum protocol for default viewer behavior.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on Default TLS settings for CloudFront, refer to the Supported protocols and ciphers between viewers and CloudFront section of the Amazon CloudFront Developer Guide",
+                        "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsCloudFrontDistribution",
+                        "Id": distributionArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsCloudFrontDistribution": {
+                                "DomainName": domainName,
+                                "Status": distStatus
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.DS-2",
+                        "NIST SP 800-53 SC-8",
+                        "NIST SP 800-53 SC-11",
+                        "NIST SP 800-53 SC-12",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.2.3",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1",
+                        "ISO 27001:2013 A.13.2.3",
+                        "ISO 27001:2013 A.14.1.2",
+                        "ISO 27001:2013 A.14.1.3"                    
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
+
+@registry.register_check("cloudfront")
+def cloudfront_custom_origin_tls12_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[CloudFront.8] Cloudfront Distributions with Custom Origins should allow only TLSv1.2 protocols"""
+    # Non compliant policies
+    nonCompliantViewerCiphers = [
+        "SSLv3",
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2"
+    ]
+    # ISO Time
+    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
+    for dist in paginate(cache):
+        distributionId = dist["Id"]
+        distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
+        # Get check specific metadata
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        if not distro["DistributionConfig"]["Origins"]["Items"]:
+            continue
+        else:
+            for orig in distro["DistributionConfig"]["Origins"]["Items"]:
+                originId = orig["Id"]
+                try:
+                    customOriginCiphers = orig["CustomOriginConfig"]["OriginSslProtocols"]["Items"]
+                    if any(x in customOriginCiphers for x in nonCompliantViewerCiphers):
+                        # this is a failing check
+                        finding = {
+                            "SchemaVersion": "2018-10-08",
+                            "Id": f"{distributionArn}/{originId}/cloudfront-custom-origin-tls12-check",
+                            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                            "GeneratorId": distributionArn,
+                            "AwsAccountId": awsAccountId,
+                            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                            "FirstObservedAt": iso8601Time,
+                            "CreatedAt": iso8601Time,
+                            "UpdatedAt": iso8601Time,
+                            "Severity": {"Label": "HIGH"},
+                            "Confidence": 99,
+                            "Title": "[CloudFront.8] Cloudfront Distributions with Custom Origins should allow only TLSv1.2 protocols",
+                            "Description": f"CloudFront Origin {originId} for Distribution {distributionId} allows a non-TLSv1.2 cipher protocol. The minimum origin SSL protocol specifies the minimum TLS/SSL protocol that CloudFront can use when it establishes an HTTPS connection to your origin. Lower TLS protocols are less secure, so we recommend that you choose the latest TLS protocol that your origin supports. For more information see the remediation section.",
+                            "Remediation": {
+                                "Recommendation": {
+                                    "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Values That You Specify When You Create or Update a Distribution section of the Amazon CloudFront Developer Guide",
+                                    "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols",
+                                }
+                            },
+                            "ProductFields": {"Product Name": "ElectricEye"},
+                            "Resources": [
+                                {
+                                    "Type": "AwsCloudFrontDistribution",
+                                    "Id": distributionArn,
+                                    "Partition": awsPartition,
+                                    "Region": awsRegion,
+                                    "Details": {
+                                        "AwsCloudFrontDistribution": {
+                                            "DomainName": domainName,
+                                            "Status": distStatus,
+                                            "Origins": {
+                                                "Items": [
+                                                    {
+                                                        "Id": originId
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "Compliance": {
+                                "Status": "FAILED",
+                                "RelatedRequirements": [
+                                    "NIST CSF PR.DS-2",
+                                    "NIST SP 800-53 SC-8",
+                                    "NIST SP 800-53 SC-11",
+                                    "NIST SP 800-53 SC-12",
+                                    "AICPA TSC CC6.1",
+                                    "ISO 27001:2013 A.8.2.3",
+                                    "ISO 27001:2013 A.13.1.1",
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "ISO 27001:2013 A.13.2.3",
+                                    "ISO 27001:2013 A.14.1.2",
+                                    "ISO 27001:2013 A.14.1.3"                    
+                                ]
+                            },
+                            "Workflow": {"Status": "NEW"},
+                            "RecordState": "ACTIVE"
+                        }
+                        yield finding
+                    else:
+                        # this is a passing check
+                        finding = {
+                            "SchemaVersion": "2018-10-08",
+                            "Id": f"{distributionArn}/{originId}/cloudfront-custom-origin-tls12-check",
+                            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                            "GeneratorId": distributionArn,
+                            "AwsAccountId": awsAccountId,
+                            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                            "FirstObservedAt": iso8601Time,
+                            "CreatedAt": iso8601Time,
+                            "UpdatedAt": iso8601Time,
+                            "Severity": {"Label": "INFORMATIONAL"},
+                            "Confidence": 99,
+                            "Title": "[CloudFront.8] Cloudfront Distributions with Custom Origins should allow only TLSv1.2 protocols",
+                            "Description": f"CloudFront Origin {originId} for Distribution {distributionId} does not allow any non-TLSv1.2 cipher protocols.",
+                            "Remediation": {
+                                "Recommendation": {
+                                    "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Values That You Specify When You Create or Update a Distribution section of the Amazon CloudFront Developer Guide",
+                                    "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols",
+                                }
+                            },
+                            "ProductFields": {"Product Name": "ElectricEye"},
+                            "Resources": [
+                                {
+                                    "Type": "AwsCloudFrontDistribution",
+                                    "Id": distributionArn,
+                                    "Partition": awsPartition,
+                                    "Region": awsRegion,
+                                    "Details": {
+                                        "AwsCloudFrontDistribution": {
+                                            "DomainName": domainName,
+                                            "Status": distStatus,
+                                            "Origins": {
+                                                "Items": [
+                                                    {
+                                                        "Id": originId
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "Compliance": {
+                                "Status": "PASSED",
+                                "RelatedRequirements": [
+                                    "NIST CSF PR.DS-2",
+                                    "NIST SP 800-53 SC-8",
+                                    "NIST SP 800-53 SC-11",
+                                    "NIST SP 800-53 SC-12",
+                                    "AICPA TSC CC6.1",
+                                    "ISO 27001:2013 A.8.2.3",
+                                    "ISO 27001:2013 A.13.1.1",
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "ISO 27001:2013 A.13.2.3",
+                                    "ISO 27001:2013 A.14.1.2",
+                                    "ISO 27001:2013 A.14.1.3"                    
+                                ]
+                            },
+                            "Workflow": {"Status": "RESOLVED"},
+                            "RecordState": "ARCHIVED"
+                        }
+                        yield finding
+                except KeyError:
+                    # KeyError exception means there is not a custom origin within the current iterated Origin
+                    # this is a passing check
+                    finding = {
+                        "SchemaVersion": "2018-10-08",
+                        "Id": f"{distributionArn}/{originId}/cloudfront-custom-origin-tls12-check",
+                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                        "GeneratorId": distributionArn,
+                        "AwsAccountId": awsAccountId,
+                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                        "FirstObservedAt": iso8601Time,
+                        "CreatedAt": iso8601Time,
+                        "UpdatedAt": iso8601Time,
+                        "Severity": {"Label": "INFORMATIONAL"},
+                        "Confidence": 99,
+                        "Title": "[CloudFront.8] Cloudfront Distributions with Custom Origins should allow only TLSv1.2 protocols",
+                        "Description": f"CloudFront Origin {originId} for Distribution {distributionId} is not a custom origin and is thus not in scope for this check.",
+                        "Remediation": {
+                            "Recommendation": {
+                                "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Values That You Specify When You Create or Update a Distribution section of the Amazon CloudFront Developer Guide",
+                                "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols",
+                            }
+                        },
+                        "ProductFields": {"Product Name": "ElectricEye"},
+                        "Resources": [
+                            {
+                                "Type": "AwsCloudFrontDistribution",
+                                "Id": distributionArn,
+                                "Partition": awsPartition,
+                                "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus,
+                                        "Origins": {
+                                            "Items": [
+                                                {
+                                                    "Id": originId
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "Compliance": {
+                            "Status": "PASSED",
+                            "RelatedRequirements": [
+                                "NIST CSF PR.DS-2",
+                                "NIST SP 800-53 SC-8",
+                                "NIST SP 800-53 SC-11",
+                                "NIST SP 800-53 SC-12",
+                                "AICPA TSC CC6.1",
+                                "ISO 27001:2013 A.8.2.3",
+                                "ISO 27001:2013 A.13.1.1",
+                                "ISO 27001:2013 A.13.2.1",
+                                "ISO 27001:2013 A.13.2.3",
+                                "ISO 27001:2013 A.14.1.2",
+                                "ISO 27001:2013 A.14.1.3"                    
+                            ]
+                        },
+                        "Workflow": {"Status": "RESOLVED"},
+                        "RecordState": "ARCHIVED"
+                    }
+                    yield finding
+
+@registry.register_check("cloudfront")
+def cloudfront_custom_origin_https_only_protcol_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[CloudFront.9] Cloudfront Distributions with Custom Origins should enforce HTTPS-only protocol policies"""
+    # ISO Time
+    iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
+    for dist in paginate(cache):
+        distributionId = dist["Id"]
+        distributionArn = dist["ARN"]
+        domainName = dist["DomainName"]
+        distStatus = dist["Status"]
+        # Get check specific metadata
+        distro = cloudfront.get_distribution(Id=distributionId)["Distribution"]
+        if not distro["DistributionConfig"]["Origins"]["Items"]:
+            continue
+        else:
+            for orig in distro["DistributionConfig"]["Origins"]["Items"]:
+                originId = orig["Id"]
+                try:
+                    if str(orig["CustomOriginConfig"]["OriginProtocolPolicy"]) != "https-only":
+                        # this is a failing check
+                        finding = {
+                            "SchemaVersion": "2018-10-08",
+                            "Id": f"{distributionArn}/{originId}/cloudfront-custom-origin-https-only-protocol-check",
+                            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                            "GeneratorId": distributionArn,
+                            "AwsAccountId": awsAccountId,
+                            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                            "FirstObservedAt": iso8601Time,
+                            "CreatedAt": iso8601Time,
+                            "UpdatedAt": iso8601Time,
+                            "Severity": {"Label": "HIGH"},
+                            "Confidence": 99,
+                            "Title": "[CloudFront.9] Cloudfront Distributions with Custom Origins should enforce HTTPS-only protocol policies",
+                            "Description": f"CloudFront Origin {originId} for Distribution {distributionId} does not enforce a HTTPS-only protocol policy. You can require HTTPS for communication between CloudFront and your origin when you specify HTTPS Only CloudFront uses only HTTPS to communicate with your custom origin. For more information see the remediation section.",
+                            "Remediation": {
+                                "Recommendation": {
+                                    "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Requiring HTTPS for communication between CloudFront and your custom origin section of the Amazon CloudFront Developer Guide",
+                                    "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-cloudfront-to-custom-origin.html",
+                                }
+                            },
+                            "ProductFields": {"Product Name": "ElectricEye"},
+                            "Resources": [
+                                {
+                                    "Type": "AwsCloudFrontDistribution",
+                                    "Id": distributionArn,
+                                    "Partition": awsPartition,
+                                    "Region": awsRegion,
+                                    "Details": {
+                                        "AwsCloudFrontDistribution": {
+                                            "DomainName": domainName,
+                                            "Status": distStatus,
+                                            "Origins": {
+                                                "Items": [
+                                                    {
+                                                        "Id": originId
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "Compliance": {
+                                "Status": "FAILED",
+                                "RelatedRequirements": [
+                                    "NIST CSF PR.DS-2",
+                                    "NIST SP 800-53 SC-8",
+                                    "NIST SP 800-53 SC-11",
+                                    "NIST SP 800-53 SC-12",
+                                    "AICPA TSC CC6.1",
+                                    "ISO 27001:2013 A.8.2.3",
+                                    "ISO 27001:2013 A.13.1.1",
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "ISO 27001:2013 A.13.2.3",
+                                    "ISO 27001:2013 A.14.1.2",
+                                    "ISO 27001:2013 A.14.1.3"                    
+                                ]
+                            },
+                            "Workflow": {"Status": "NEW"},
+                            "RecordState": "ACTIVE"
+                        }
+                        yield finding
+                    else:
+                        # this is a passing check
+                        finding = {
+                            "SchemaVersion": "2018-10-08",
+                            "Id": f"{distributionArn}/{originId}/cloudfront-custom-origin-https-only-protocol-check",
+                            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                            "GeneratorId": distributionArn,
+                            "AwsAccountId": awsAccountId,
+                            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                            "FirstObservedAt": iso8601Time,
+                            "CreatedAt": iso8601Time,
+                            "UpdatedAt": iso8601Time,
+                            "Severity": {"Label": "INFORMATIONAL"},
+                            "Confidence": 99,
+                            "Title": "[CloudFront.9] Cloudfront Distributions with Custom Origins should enforce HTTPS-only protocol policies",
+                            "Description": f"CloudFront Origin {originId} for Distribution {distributionId} enforces a HTTPS-only protocol policy.",
+                            "Remediation": {
+                                "Recommendation": {
+                                    "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Requiring HTTPS for communication between CloudFront and your custom origin section of the Amazon CloudFront Developer Guide",
+                                    "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-cloudfront-to-custom-origin.html",
+                                }
+                            },
+                            "ProductFields": {"Product Name": "ElectricEye"},
+                            "Resources": [
+                                {
+                                    "Type": "AwsCloudFrontDistribution",
+                                    "Id": distributionArn,
+                                    "Partition": awsPartition,
+                                    "Region": awsRegion,
+                                    "Details": {
+                                        "AwsCloudFrontDistribution": {
+                                            "DomainName": domainName,
+                                            "Status": distStatus,
+                                            "Origins": {
+                                                "Items": [
+                                                    {
+                                                        "Id": originId
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "Compliance": {
+                                "Status": "PASSED",
+                                "RelatedRequirements": [
+                                    "NIST CSF PR.DS-2",
+                                    "NIST SP 800-53 SC-8",
+                                    "NIST SP 800-53 SC-11",
+                                    "NIST SP 800-53 SC-12",
+                                    "AICPA TSC CC6.1",
+                                    "ISO 27001:2013 A.8.2.3",
+                                    "ISO 27001:2013 A.13.1.1",
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "ISO 27001:2013 A.13.2.3",
+                                    "ISO 27001:2013 A.14.1.2",
+                                    "ISO 27001:2013 A.14.1.3"                    
+                                ]
+                            },
+                            "Workflow": {"Status": "RESOLVED"},
+                            "RecordState": "ARCHIVED"
+                        }
+                        yield finding
+                except KeyError:
+                    # KeyError exception means there is not a custom origin within the current iterated Origin
+                    # this is a passing check
+                    finding = {
+                        "SchemaVersion": "2018-10-08",
+                        "Id": f"{distributionArn}/{originId}/cloudfront-custom-origin-https-only-protocol-check",
+                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                        "GeneratorId": distributionArn,
+                        "AwsAccountId": awsAccountId,
+                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                        "FirstObservedAt": iso8601Time,
+                        "CreatedAt": iso8601Time,
+                        "UpdatedAt": iso8601Time,
+                        "Severity": {"Label": "INFORMATIONAL"},
+                        "Confidence": 99,
+                        "Title": "[CloudFront.9] Cloudfront Distributions with Custom Origins should enforce HTTPS-only protocol policies",
+                        "Description": f"CloudFront Origin {originId} for Distribution {distributionId} is not a custom origin and is thus not in scope for this check.",
+                        "Remediation": {
+                            "Recommendation": {
+                                "Text": "For more information on Custom Origin TLS settings for CloudFront, refer to the Requiring HTTPS for communication between CloudFront and your custom origin section of the Amazon CloudFront Developer Guide",
+                                "Url": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-cloudfront-to-custom-origin.html",
+                            }
+                        },
+                        "ProductFields": {"Product Name": "ElectricEye"},
+                        "Resources": [
+                            {
+                                "Type": "AwsCloudFrontDistribution",
+                                "Id": distributionArn,
+                                "Partition": awsPartition,
+                                "Region": awsRegion,
+                                "Details": {
+                                    "AwsCloudFrontDistribution": {
+                                        "DomainName": domainName,
+                                        "Status": distStatus,
+                                        "Origins": {
+                                            "Items": [
+                                                {
+                                                    "Id": originId
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "Compliance": {
+                            "Status": "PASSED",
+                            "RelatedRequirements": [
+                                "NIST CSF PR.DS-2",
+                                "NIST SP 800-53 SC-8",
+                                "NIST SP 800-53 SC-11",
+                                "NIST SP 800-53 SC-12",
+                                "AICPA TSC CC6.1",
+                                "ISO 27001:2013 A.8.2.3",
+                                "ISO 27001:2013 A.13.1.1",
+                                "ISO 27001:2013 A.13.2.1",
+                                "ISO 27001:2013 A.13.2.3",
+                                "ISO 27001:2013 A.14.1.2",
+                                "ISO 27001:2013 A.14.1.3"                    
+                            ]
+                        },
+                        "Workflow": {"Status": "RESOLVED"},
+                        "RecordState": "ARCHIVED"
+                    }
+                    yield finding
 
 ## TODO: NEXT

--- a/eeauditor/auditors/aws/Amazon_ElasticsearchService_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_ElasticsearchService_Auditor.py
@@ -104,8 +104,8 @@ def dedicated_master_check(cache: dict, awsAccountId: str, awsRegion: str, awsPa
                         "ISO 27001:2013 A.11.1.4",
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
-                        "ISO 27001:2013 A.17.2.1",
-                    ],
+                        "ISO 27001:2013 A.17.2.1"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
                 "RecordState": "ACTIVE",
@@ -164,8 +164,8 @@ def dedicated_master_check(cache: dict, awsAccountId: str, awsRegion: str, awsPa
                         "ISO 27001:2013 A.11.1.4",
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
-                        "ISO 27001:2013 A.17.2.1",
-                    ],
+                        "ISO 27001:2013 A.17.2.1"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
                 "RecordState": "ARCHIVED",

--- a/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
@@ -1162,11 +1162,11 @@ def rds_instance_cloudwatch_logging_check(cache: dict, awsAccountId: str, awsReg
                         "NIST SP 800-53 SI-4",
                         "AICPA TSC CC7.2",
                         "ISO 27001:2013 A.12.4.1",
-                        "ISO 27001:2013 A.16.1.7",
-                    ],
+                        "ISO 27001:2013 A.16.1.7"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
-                "RecordState": "ARCHIVED",
+                "RecordState": "ARCHIVED"
             }
             yield finding
         except:
@@ -1222,11 +1222,11 @@ def rds_instance_cloudwatch_logging_check(cache: dict, awsAccountId: str, awsReg
                         "NIST SP 800-53 SI-4",
                         "AICPA TSC CC7.2",
                         "ISO 27001:2013 A.12.4.1",
-                        "ISO 27001:2013 A.16.1.7",
-                    ],
+                        "ISO 27001:2013 A.16.1.7"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
+                "RecordState": "ACTIVE"
             }
             yield finding
 

--- a/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
@@ -69,8 +69,6 @@ def rds_instance_ha_check(cache: dict, awsAccountId: str, awsRegion: str, awsPar
     """[RDS.1] RDS instances should be configured for high availability"""
     response = describe_db_instances(cache)
     myRdsInstances = response["DBInstances"]
-    response = describe_db_snapshots(cache)
-    myRdsSnapshots = response["DBSnapshots"]
     for dbinstances in myRdsInstances:
         instanceArn = str(dbinstances["DBInstanceArn"])
         instanceId = str(dbinstances["DBInstanceIdentifier"])

--- a/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
@@ -1409,11 +1409,11 @@ def rds_snapshot_public_share_check(cache: dict, awsAccountId: str, awsRegion: s
                                 "ISO 27001:2013 A.6.2.2",
                                 "ISO 27001:2013 A.11.2.6",
                                 "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1",
-                            ],
+                                "ISO 27001:2013 A.13.2.1"
+                            ]
                         },
                         "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
+                        "RecordState": "ACTIVE"
                     }
                     yield finding
                 else:
@@ -1465,11 +1465,11 @@ def rds_snapshot_public_share_check(cache: dict, awsAccountId: str, awsRegion: s
                                 "ISO 27001:2013 A.6.2.2",
                                 "ISO 27001:2013 A.11.2.6",
                                 "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1",
-                            ],
+                                "ISO 27001:2013 A.13.2.1"
+                            ]
                         },
                         "Workflow": {"Status": "RESOLVED"},
-                        "RecordState": "ARCHIVED",
+                        "RecordState": "ARCHIVED"
                     }
                     yield finding
             else:

--- a/eeauditor/auditors/aws/ElectricEye_AttackSurface_Auditor.py
+++ b/eeauditor/auditors/aws/ElectricEye_AttackSurface_Auditor.py
@@ -759,7 +759,7 @@ def eip_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                         "Severity": {"Label": "INFORMATIONAL"},
                         "Confidence": 99,
                         "Title": f"[AttackSurface.EIP.{checkIdNumber}] Elastic IPs should not advertise publicly reachable {serviceName} services",
-                        "Description": f"Elastic IP address {publicIp} is publicly reachable on port {portNumber} which corresponds to the {serviceName} service due to {serviceStateReason}. EIPs and their respective Security Groups should still be reviewed for minimum necessary access.",
+                        "Description": f"Elastic IP address {publicIp} is not publicly reachable on port {portNumber} which corresponds to the {serviceName} service due to {serviceStateReason}. EIPs and their respective Security Groups should still be reviewed for minimum necessary access.",
                         "Remediation": {
                             "Recommendation": {
                                 "Text": "EC2 Instances should only have the minimum necessary ports open to achieve their purposes, allow traffic from authorized sources, and use other defense-in-depth and hardening strategies. For a basic view on traffic authorization into your instances refer to the Authorize inbound traffic for your Linux instances section of the Amazon Elastic Compute Cloud User Guide",

--- a/eeauditor/auditors/aws/ElectricEye_AttackSurface_Auditor.py
+++ b/eeauditor/auditors/aws/ElectricEye_AttackSurface_Auditor.py
@@ -183,7 +183,13 @@ def ec2_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                                     "ISO 27001:2013 A.6.2.2",
                                     "ISO 27001:2013 A.11.2.6",
                                     "ISO 27001:2013 A.13.1.1",
-                                    "ISO 27001:2013 A.13.2.1"
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "MITRE ATT&CK T1040",
+                                    "MITRE ATT&CK T1046",
+                                    "MITRE ATT&CK T1580",
+                                    "MITRE ATT&CK T1590",
+                                    "MITRE ATT&CK T1592",
+                                    "MITRE ATT&CK T1595"
                                 ]
                             },
                             "Workflow": {"Status": "NEW"},
@@ -246,7 +252,13 @@ def ec2_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                                     "ISO 27001:2013 A.6.2.2",
                                     "ISO 27001:2013 A.11.2.6",
                                     "ISO 27001:2013 A.13.1.1",
-                                    "ISO 27001:2013 A.13.2.1"
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "MITRE ATT&CK T1040",
+                                    "MITRE ATT&CK T1046",
+                                    "MITRE ATT&CK T1580",
+                                    "MITRE ATT&CK T1590",
+                                    "MITRE ATT&CK T1592",
+                                    "MITRE ATT&CK T1595"
                                 ]
                             },
                             "Workflow": {"Status": "RESOLVED"},
@@ -353,7 +365,13 @@ def elbv2_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, aws
                                     "ISO 27001:2013 A.6.2.2",
                                     "ISO 27001:2013 A.11.2.6",
                                     "ISO 27001:2013 A.13.1.1",
-                                    "ISO 27001:2013 A.13.2.1"
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "MITRE ATT&CK T1040",
+                                    "MITRE ATT&CK T1046",
+                                    "MITRE ATT&CK T1580",
+                                    "MITRE ATT&CK T1590",
+                                    "MITRE ATT&CK T1592",
+                                    "MITRE ATT&CK T1595"
                                 ]
                             },
                             "Workflow": {"Status": "NEW"},
@@ -416,7 +434,13 @@ def elbv2_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, aws
                                     "ISO 27001:2013 A.6.2.2",
                                     "ISO 27001:2013 A.11.2.6",
                                     "ISO 27001:2013 A.13.1.1",
-                                    "ISO 27001:2013 A.13.2.1"
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "MITRE ATT&CK T1040",
+                                    "MITRE ATT&CK T1046",
+                                    "MITRE ATT&CK T1580",
+                                    "MITRE ATT&CK T1590",
+                                    "MITRE ATT&CK T1592",
+                                    "MITRE ATT&CK T1595"
                                 ]
                             },
                             "Workflow": {"Status": "RESOLVED"},
@@ -527,7 +551,13 @@ def elb_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                                     "ISO 27001:2013 A.6.2.2",
                                     "ISO 27001:2013 A.11.2.6",
                                     "ISO 27001:2013 A.13.1.1",
-                                    "ISO 27001:2013 A.13.2.1"
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "MITRE ATT&CK T1040",
+                                    "MITRE ATT&CK T1046",
+                                    "MITRE ATT&CK T1580",
+                                    "MITRE ATT&CK T1590",
+                                    "MITRE ATT&CK T1592",
+                                    "MITRE ATT&CK T1595"
                                 ]
                             },
                             "Workflow": {"Status": "NEW"},
@@ -592,7 +622,13 @@ def elb_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                                     "ISO 27001:2013 A.6.2.2",
                                     "ISO 27001:2013 A.11.2.6",
                                     "ISO 27001:2013 A.13.1.1",
-                                    "ISO 27001:2013 A.13.2.1"
+                                    "ISO 27001:2013 A.13.2.1",
+                                    "MITRE ATT&CK T1040",
+                                    "MITRE ATT&CK T1046",
+                                    "MITRE ATT&CK T1580",
+                                    "MITRE ATT&CK T1590",
+                                    "MITRE ATT&CK T1592",
+                                    "MITRE ATT&CK T1595"
                                 ]
                             },
                             "Workflow": {"Status": "RESOLVED"},
@@ -693,7 +729,13 @@ def eip_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                                 "ISO 27001:2013 A.6.2.2",
                                 "ISO 27001:2013 A.11.2.6",
                                 "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1"
+                                "ISO 27001:2013 A.13.2.1",
+                                "MITRE ATT&CK T1040",
+                                "MITRE ATT&CK T1046",
+                                "MITRE ATT&CK T1580",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1592",
+                                "MITRE ATT&CK T1595"
                             ]
                         },
                         "Workflow": {"Status": "NEW"},
@@ -754,7 +796,13 @@ def eip_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str, awsRe
                                 "ISO 27001:2013 A.6.2.2",
                                 "ISO 27001:2013 A.11.2.6",
                                 "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1"
+                                "ISO 27001:2013 A.13.2.1",
+                                "MITRE ATT&CK T1040",
+                                "MITRE ATT&CK T1046",
+                                "MITRE ATT&CK T1580",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1592",
+                                "MITRE ATT&CK T1595"
                             ]
                         },
                         "Workflow": {"Status": "RESOLVED"},

--- a/eeauditor/auditors/aws/ElectricEye_AttackSurface_Auditor.py
+++ b/eeauditor/auditors/aws/ElectricEye_AttackSurface_Auditor.py
@@ -997,3 +997,5 @@ def cloudfront_attack_surface_open_tcp_port_check(cache: dict, awsAccountId: str
                         "RecordState": "ARCHIVED"
                     }
                     yield finding
+
+# TODO: Route 53 Public Hosted Zone, Global Accelerator

--- a/policies/ElectricEye_ECS_Task_Role_Policy.json
+++ b/policies/ElectricEye_ECS_Task_Role_Policy.json
@@ -7,6 +7,7 @@
             "Action": [
                 "airflow:GetEnvironment",
                 "airflow:ListEnvironments",
+                "autoscaling:DescribeAutoScalingGroups",
                 "cloudtrail:DescribeTrails",
                 "cloudtrail:ListTrails",
                 "kms:DescribeKey",

--- a/terraform-config-files/electric_eye.tf
+++ b/terraform-config-files/electric_eye.tf
@@ -248,6 +248,7 @@ resource "aws_iam_role_policy" "Electric_Eye_Task_Role_Policy" {
             "Action": [
                 "airflow:GetEnvironment",
                 "airflow:ListEnvironments",
+                "autoscaling:DescribeAutoScalingGroups",
                 "cloudtrail:DescribeTrails",
                 "cloudtrail:ListTrails",
                 "kms:DescribeKey",


### PR DESCRIPTION
This PR is focused mainly on CloudFront - coming to parity (and also surpassing) AWS Security Hub Foundational Security Best Practice controls for Amazon CloudFront and adding CloudFront to the ASM Auditor. Additionally, minor changes to the README have been made and a new Autoscaling Group Auditor was added with 3 new checks.

The CloudFront rewrite has changed every single Finding ID which will lead to some duplicated findings within your AWS Security Hub/SIEM/DB/BI report for CloudFront - however the previous implementation was incredibly poor having many true negatives show up and was not implemented as best as it could.

This PR adds 35 new checks, supports 1 new resource, and adds 1 new Auditor.

Some detailed changes...
- Add a proper paginator and caching for CloudFront in ASM and CloudFront Auditor - these gets rid of the `extend()` and `iter()` hacks getting access into items.

- Completely rewrote every single existing CloudFront check, properly oriented ASFF `id` around CloudFront ARNs and optionally namespace their Origin IDs if multiple Origins are in use for specific checks.

- Rewrote True Negative producing CloudFront checks such as the Default Viewer Certificate, Origin TLS, Default Cache TLS and added new checks of OAI, HTTPS-only enforcement, custom root object, and logging enablement

- Added MITRE ATT&CK Technique (e.g, `T.xxxx`) mappings into `Compliance.RelatedRequirements` for all ASM Checks and made small spot changes to finding descriptions

- Added an Autoscaling Group Auditor, rewrote some FSBP checks and added a scale-in protection check as well

- Added CloudFront to the ASM Auditor and tested with S3 and Custom Origins

- README structure changes, IAM changes, Repo description change, and added a new example output to run ASM checks