### PR TITLE
Add "log_fwd" PostgreSQL/Aurora PostgreSQL Checks & `STDOUT` Output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@
 #specific language governing permissions and limitations
 #under the License.
 
-# latest hash as of 29 MAR 2022 - Alpine 3.15.3
-# https://hub.docker.com/layers/alpine/library/alpine/3.15.3/images/sha256-1e014f84205d569a5cc3be4e108ca614055f7e21d11928946113ab3f36054801?context=explore
+# latest hash as of 8 MAR 2022 - Alpine 3.15.4
+# https://hub.docker.com/layers/alpine/library/alpine/3.15.4/images/sha256-a777c9c66ba177ccfea23f2a216ff6721e78a662cd17019488c417135299cd89?context=explore
 # use as builder image to pull in required deps
-FROM alpine@sha256:1e014f84205d569a5cc3be4e108ca614055f7e21d11928946113ab3f36054801 AS builder
+FROM alpine@sha256:a777c9c66ba177ccfea23f2a216ff6721e78a662cd17019488c417135299cd89 AS builder
 
 # This hack is widely applied to avoid python printing issues in docker containers.
 # See: https://github.com/Docker-Hub-frolvlad/docker-alpine-python3/pull/13

--- a/README.md
+++ b/README.md
@@ -504,7 +504,10 @@ In this stage we will use the console the manually run the ElectricEye ECS task,
 
 ## Supported Services and Checks
 
-These are the following services and checks perform by each Auditor. There are currently :boom: **524 Checks** :boom: supported across :exclamation: **95 AWS services/components** :exclamation: with a total of :fire: **73 Auditors** :fire:
+These are the following services and checks perform by each Auditor, there are currently...
+- :boom: **526 Checks** :boom:
+- :exclamation: **95 AWS supported services/components** :exclamation:
+- :fire: **73 Auditors** :fire:
 
 There are currently **62** supported response and remediation Playbooks with coverage across **32** AWS services / components supported by [ElectricEye-Response](https://github.com/jonrau1/ElectricEye/blob/master/add-ons/electriceye-response).
 
@@ -712,6 +715,8 @@ There are currently **62** supported response and remediation Playbooks with cov
 | Amazon_RDS_Auditor.py | RDS DB Instance | Does the instance security group allow risky access |
 | Amazon_RDS_Auditor.py | Event Subscription (Account) | Does an Event Subscription to monitor DB instances exist |
 | Amazon_RDS_Auditor.py | Event Subscription (Account) | Does an Event Subscription to monitor paramter groups exist |
+| Amazon_RDS_Auditor.py | RDS DB Instance | Do PostgreSQL instances use a version susceptible to Lightspin "log_fwd" attack |
+| Amazon_RDS_Auditor.py | RDS DB Instance | Do Aurora PostgreSQL instances use a version susceptible to Lightspin "log_fwd" attack |
 | Amazon_Redshift_Auditor.py | Redshift cluster | Is the cluster publicly accessible |
 | Amazon_Redshift_Auditor.py | Redshift cluster | Is the cluster encrypted at rest |
 | Amazon_Redshift_Auditor.py | Redshift cluster | Is enhanced VPC routing enabled |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Continuously monitor your AWS attack surface and evaluate services for configura
 ***Everything you do***<br/>
 <sub>*Judas Priest, 1982*</sub>
 
+## Super Quick Start :running: :running:
+
+```bash
+git clone https://github.com/jonrau1/ElectricEye.git
+cd ElectricEye
+python3 eeauditor/controller.py -o stdout
+```
+
 ## Table of Contents
 
 - [Synopsis](#synopsis)

--- a/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
@@ -2434,7 +2434,7 @@ def rds_instance_parameter_group_alerting_check(cache: dict, awsAccountId: str, 
                 if all(x in ["maintenance", "configuration change", "failure"] for x in eventList):
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": f"{awsAccountId}:{awsRegion}/rds-instance-event-sub-check",
+                        "Id": f"{awsAccountId}:{awsRegion}/rds-pg-event-sub-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": f"{awsAccountId}:{awsRegion}",
                         "AwsAccountId": awsAccountId,
@@ -2483,7 +2483,7 @@ def rds_instance_parameter_group_alerting_check(cache: dict, awsAccountId: str, 
                 else:
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": f"{awsAccountId}:{awsRegion}/rds-instance-event-sub-check",
+                        "Id": f"{awsAccountId}:{awsRegion}/rds-pg-event-sub-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": f"{awsAccountId}:{awsRegion}",
                         "AwsAccountId": awsAccountId,
@@ -2533,7 +2533,7 @@ def rds_instance_parameter_group_alerting_check(cache: dict, awsAccountId: str, 
             except KeyError:
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": f"{awsAccountId}:{awsRegion}/rds-instance-event-sub-check",
+                    "Id": f"{awsAccountId}:{awsRegion}/rds-pg-event-sub-check",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                     "GeneratorId": f"{awsAccountId}:{awsRegion}",
                     "AwsAccountId": awsAccountId,
@@ -2583,7 +2583,7 @@ def rds_instance_parameter_group_alerting_check(cache: dict, awsAccountId: str, 
     else:
         finding = {
             "SchemaVersion": "2018-10-08",
-            "Id": f"{awsAccountId}:{awsRegion}/rds-instance-event-sub-check",
+            "Id": f"{awsAccountId}:{awsRegion}/rds-pg-event-sub-check",
             "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
             "GeneratorId": f"{awsAccountId}:{awsRegion}",
             "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_RDS_Auditor.py
@@ -2629,3 +2629,326 @@ def rds_instance_parameter_group_alerting_check(cache: dict, awsAccountId: str, 
             "RecordState": "ACTIVE"
         }
         yield finding
+
+@registry.register_check("rds")
+def rds_postgresql_log_fwd_vuln_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[RDS.17] RDS instances with PostgreSQL engines should not use a version that is vulnerable to the Lightspin log_fwd internal cluster access attack"""
+    # from https://aws.amazon.com/security/security-bulletins/AWS-2022-004/
+    vulnerableMinorVersions = [
+        "13.2",
+        "13.1",
+        "12.6",
+        "12.5",
+        "12.4",
+        "12.3",
+        "12.2",
+        "11.11",
+        "11.10",
+        "11.9",
+        "11.8",
+        "11.7",
+        "11.6",
+        "11.5",
+        "11.5",
+        "11.4",
+        "11.3",
+        "11.2",
+        "11.1",
+        "10.16",
+        "10.15",
+        "10.14",
+        "10.13",
+        "10.12",
+        "10.11",
+        "10.10",
+        "10.9",
+        "10.7",
+        "10.6",
+        "10.5",
+        "10.4",
+        "10.3",
+        "10.1",
+        "9.6.21",
+        "9.6.20",
+        "9.6.19",
+        "9.6.18",
+        "9.6.17",
+        "9.6.16",
+        "9.6.15",
+        "9.6.14",
+        "9.6.12",
+        "9.6.11",
+        "9.6.10",
+        "9.6.9",
+        "9.6.8",
+        "9.6.6",
+        "9.6.5",
+        "9.6.3",
+        "9.6.2",
+        "9.6.1",
+        "9.5",
+        "9.4",
+        "9.3"
+    ]
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for dbinstances in describe_db_instances(cache):
+        instanceArn = str(dbinstances["DBInstanceArn"])
+        instanceId = str(dbinstances["DBInstanceIdentifier"])
+        instanceClass = str(dbinstances["DBInstanceClass"])
+        instancePort = int(dbinstances["Endpoint"]["Port"])
+        instanceEngine = str(dbinstances["Engine"])
+        instanceEngineVersion = str(dbinstances["EngineVersion"])
+        # skip over "aurora-postgresql" as we have a seperate check for it
+        if instanceEngine == "aurora-postgresql":
+            continue
+        elif instanceEngine == "postgres":
+            # this is a failing check
+            if instanceEngineVersion in vulnerableMinorVersions:
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": f"{instanceArn}/instance-rds-postgresql-logfwd-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": instanceArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "MEDIUM"},
+                    "Confidence": 99,
+                    "Title": "[RDS.17] RDS instances with PostgreSQL engines should not use a version that is vulnerable to the Lightspin log_fwd internal cluster access attack",
+                    "Description": f"RDS DB Instances {instanceId} is susceptible to the Lightspin 'log_fwd' attack against PostgreSQL engines due to running engine version {instanceEngineVersion}. This attack utilizes a local file read vulnerability within the 'log_fwd' extension to access underlying Cluster metadata, escalate privileges, and access the 'GROVER' service underneath. To remediate this vulnerability you must upgrade to the latest version of PostgreSQL.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "For more information on the attack refer to the Reported Amazon RDS PostgreSQL issue security bulletin",
+                            "Url": "https://aws.amazon.com/security/security-bulletins/AWS-2022-004/",
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsRdsDbInstance",
+                            "Id": instanceArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion,
+                            "Details": {
+                                "AwsRdsDbInstance": {
+                                    "DBInstanceIdentifier": instanceId,
+                                    "DBInstanceClass": instanceClass,
+                                    "DbInstancePort": instancePort,
+                                    "Engine": instanceEngine,
+                                    "EngineVersion": instanceEngineVersion
+                                }
+                            }
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "FAILED",
+                        "RelatedRequirements": [
+                            "NIST CSF ID.RA-1",
+                            "NIST CSF ID.RA-3",
+                            "NIST CSF ID.RA-5",
+                            "NIST CSF ID.SC-1",
+                            "NIST SP 800-53 CA-2",
+                            "NIST SP 800-53 CA-7",
+                            "NIST SP 800-53 CA-8",
+                            "NIST SP 800-53 PM-9",
+                            "NIST SP 800-53 PM-11",
+                            "NIST SP 800-53 PM-16",
+                            "NIST SP 800-53 RA-3",
+                            "NIST SP 800-53 RA-5",
+                            "NIST SP 800-53 SA-5",
+                            "NIST SP 800-53 SA-9",
+                            "NIST SP 800-53 SA-11",
+                            "NIST SP 800-53 SA-12",
+                            "NIST SP 800-53 SA-14",
+                            "NIST SP 800-53 SI-2",
+                            "NIST SP 800-53 SI-4",
+                            "NIST SP 800-53 SI-5",
+                            "ISO 27001:2013 A.12.6.1",
+                            "ISO 27001:2013 A.15.1.1",
+                            "ISO 27001:2013 A.15.1.2",
+                            "ISO 27001:2013 A.15.1.3",
+                            "ISO 27001:2013 A.15.2.1",
+                            "ISO 27001:2013 A.15.2.2",
+                            "ISO 27001:2013 A.18.2.3",
+                            "ISO 27001:2013 Clause 6.1.2",
+                            "AICPA TSC CC3.2",
+                            "AICPA TSC CC9.2",
+                            "MITRE ATT&CK T1003",
+                            "MITRE ATT&CK T1212",
+                            "MITRE ATT&CK T1550",
+                            "MITRE ATT&CK T1195"
+                        ]
+                    },
+                    "Workflow": {"Status": "NEW"},
+                    "RecordState": "ACTIVE"
+                }
+                yield finding
+            # this is a passing check
+            else:
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": f"{instanceArn}/instance-rds-postgresql-logfwd-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": instanceArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "INFORMATIONAL"},
+                    "Confidence": 99,
+                    "Title": "[RDS.17] RDS instances with PostgreSQL engines should not use a version that is vulnerable to the Lightspin log_fwd internal cluster access attack",
+                    "Description": f"RDS DB Instances {instanceId} is not susceptible to the Lightspin 'log_fwd' attack against PostgreSQL engines due to running engine version {instanceEngineVersion}.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "For more information on the attack refer to the Reported Amazon RDS PostgreSQL issue security bulletin",
+                            "Url": "https://aws.amazon.com/security/security-bulletins/AWS-2022-004/",
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsRdsDbInstance",
+                            "Id": instanceArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion,
+                            "Details": {
+                                "AwsRdsDbInstance": {
+                                    "DBInstanceIdentifier": instanceId,
+                                    "DBInstanceClass": instanceClass,
+                                    "DbInstancePort": instancePort,
+                                    "Engine": instanceEngine,
+                                    "EngineVersion": instanceEngineVersion
+                                }
+                            }
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "PASSED",
+                        "RelatedRequirements": [
+                            "NIST CSF ID.RA-1",
+                            "NIST CSF ID.RA-3",
+                            "NIST CSF ID.RA-5",
+                            "NIST CSF ID.SC-1",
+                            "NIST SP 800-53 CA-2",
+                            "NIST SP 800-53 CA-7",
+                            "NIST SP 800-53 CA-8",
+                            "NIST SP 800-53 PM-9",
+                            "NIST SP 800-53 PM-11",
+                            "NIST SP 800-53 PM-16",
+                            "NIST SP 800-53 RA-3",
+                            "NIST SP 800-53 RA-5",
+                            "NIST SP 800-53 SA-5",
+                            "NIST SP 800-53 SA-9",
+                            "NIST SP 800-53 SA-11",
+                            "NIST SP 800-53 SA-12",
+                            "NIST SP 800-53 SA-14",
+                            "NIST SP 800-53 SI-2",
+                            "NIST SP 800-53 SI-4",
+                            "NIST SP 800-53 SI-5",
+                            "ISO 27001:2013 A.12.6.1",
+                            "ISO 27001:2013 A.15.1.1",
+                            "ISO 27001:2013 A.15.1.2",
+                            "ISO 27001:2013 A.15.1.3",
+                            "ISO 27001:2013 A.15.2.1",
+                            "ISO 27001:2013 A.15.2.2",
+                            "ISO 27001:2013 A.18.2.3",
+                            "ISO 27001:2013 Clause 6.1.2",
+                            "AICPA TSC CC3.2",
+                            "AICPA TSC CC9.2",
+                            "MITRE ATT&CK T1003",
+                            "MITRE ATT&CK T1212",
+                            "MITRE ATT&CK T1550",
+                            "MITRE ATT&CK T1195"
+                        ]
+                    },
+                    "Workflow": {"Status": "RESOLVED"},
+                    "RecordState": "ARCHIVED"
+                }
+                yield finding
+        else:
+            # this is a passing check due to exemption
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{instanceArn}/instance-rds-postgresql-logfwd-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": instanceArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[RDS.17] RDS instances with PostgreSQL engines should not use a version that is vulnerable to the Lightspin log_fwd internal cluster access attack",
+                "Description": f"RDS DB Instances {instanceId} is not susceptible to the Lightspin 'log_fwd' because it is not running a PostgreSQL Engine version and is thus exempt from this check.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For more information on the attack refer to the Reported Amazon RDS PostgreSQL issue security bulletin",
+                        "Url": "https://aws.amazon.com/security/security-bulletins/AWS-2022-004/",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsRdsDbInstance",
+                        "Id": instanceArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsRdsDbInstance": {
+                                "DBInstanceIdentifier": instanceId,
+                                "DBInstanceClass": instanceClass,
+                                "DbInstancePort": instancePort,
+                                "Engine": instanceEngine,
+                                "EngineVersion": instanceEngineVersion
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF ID.RA-1",
+                        "NIST CSF ID.RA-3",
+                        "NIST CSF ID.RA-5",
+                        "NIST CSF ID.SC-1",
+                        "NIST SP 800-53 CA-2",
+                        "NIST SP 800-53 CA-7",
+                        "NIST SP 800-53 CA-8",
+                        "NIST SP 800-53 PM-9",
+                        "NIST SP 800-53 PM-11",
+                        "NIST SP 800-53 PM-16",
+                        "NIST SP 800-53 RA-3",
+                        "NIST SP 800-53 RA-5",
+                        "NIST SP 800-53 SA-5",
+                        "NIST SP 800-53 SA-9",
+                        "NIST SP 800-53 SA-11",
+                        "NIST SP 800-53 SA-12",
+                        "NIST SP 800-53 SA-14",
+                        "NIST SP 800-53 SI-2",
+                        "NIST SP 800-53 SI-4",
+                        "NIST SP 800-53 SI-5",
+                        "ISO 27001:2013 A.12.6.1",
+                        "ISO 27001:2013 A.15.1.1",
+                        "ISO 27001:2013 A.15.1.2",
+                        "ISO 27001:2013 A.15.1.3",
+                        "ISO 27001:2013 A.15.2.1",
+                        "ISO 27001:2013 A.15.2.2",
+                        "ISO 27001:2013 A.18.2.3",
+                        "ISO 27001:2013 Clause 6.1.2",
+                        "AICPA TSC CC3.2",
+                        "AICPA TSC CC9.2",
+                        "MITRE ATT&CK T1003",
+                        "MITRE ATT&CK T1212",
+                        "MITRE ATT&CK T1550",
+                        "MITRE ATT&CK T1195"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding

--- a/eeauditor/processor/outputs/stdout.py
+++ b/eeauditor/processor/outputs/stdout.py
@@ -17,6 +17,7 @@
 #KIND, either express or implied.  See the License for the
 #specific language governing permissions and limitations
 #under the License.
+import json
 from processor.outputs.output_base import ElectricEyeOutput
 
 @ElectricEyeOutput
@@ -25,6 +26,6 @@ class StdoutProvider(object):
 
     def write_findings(self, findings: list, output_file: str, **kwargs):
         for finding in findings:
-            print(finding)
+            print(json.dumps(finding,default=str))
             
         return True

--- a/eeauditor/processor/outputs/stdout.py
+++ b/eeauditor/processor/outputs/stdout.py
@@ -25,7 +25,13 @@ class StdoutProvider(object):
     __provider__ = "stdout"
 
     def write_findings(self, findings: list, output_file: str, **kwargs):
+        checkedIds = []
+
         for finding in findings:
-            print(json.dumps(finding,default=str))
+            if finding["Id"] not in checkedIds:
+                checkedIds.append(finding["Id"])
+                print(json.dumps(finding,default=str))
+            else:
+                continue
             
         return True

--- a/eeauditor/processor/outputs/stdout.py
+++ b/eeauditor/processor/outputs/stdout.py
@@ -1,0 +1,30 @@
+#This file is part of ElectricEye.
+#SPDX-License-Identifier: Apache-2.0
+
+#Licensed to the Apache Software Foundation (ASF) under one
+#or more contributor license agreements.  See the NOTICE file
+#distributed with this work for additional information
+#regarding copyright ownership.  The ASF licenses this file
+#to you under the Apache License, Version 2.0 (the
+#"License"); you may not use this file except in compliance
+#with the License.  You may obtain a copy of the License at
+
+#http://www.apache.org/licenses/LICENSE-2.0
+
+#Unless required by applicable law or agreed to in writing,
+#software distributed under the License is distributed on an
+#"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#KIND, either express or implied.  See the License for the
+#specific language governing permissions and limitations
+#under the License.
+from processor.outputs.output_base import ElectricEyeOutput
+
+@ElectricEyeOutput
+class StdoutProvider(object):
+    __provider__ = "stdout"
+
+    def write_findings(self, findings: list, output_file: str, **kwargs):
+        for finding in findings:
+            print(finding)
+            
+        return True


### PR DESCRIPTION
Quicky PR to add checks for Amazon RDS `postgres` and `aurora-postgresql` Engines that are running susceptible engine versions as outlined in AWS' Security Bulletin AWS-2022-004 (https://aws.amazon.com/security/security-bulletins/AWS-2022-004/) in response to the Lightspin `log_fwd` local file read vulnerability that can access the "Grover" service (https://blog.lightspin.io/aws-rds-critical-security-vulnerability)

This takes ElectricEye to 526 checks in total.

Also added a `STDOUT` output to ElectricEye - for those who would rather do some grep/awk/jq magic or otherwise not mess with outputting the findings to a DB, Security Hub or to a file.

Small README updates and fixed an overlapping finding ID for RDS Event Notification checks on Parameter Groups.