### PR TITLE
WAF Coveage & MITRE ATT&CK Mappings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@
 #specific language governing permissions and limitations
 #under the License.
 
-# latest hash as of 19 JUL 2022 - Alpine 3.15.5
-# https://hub.docker.com/layers/alpine/library/alpine/3.15.5/images/sha256-26284c09912acfc5497b462c5da8a2cd14e01b4f3ffa876596f5289dd8eab7f2?context=explore
+# latest hash as of 8 AUG 2022 - Alpine 3.16.2
+# https://hub.docker.com/layers/library/alpine/3.16.2/images/sha256-1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?context=explore
 # use as builder image to pull in required deps
-FROM alpine@sha256:26284c09912acfc5497b462c5da8a2cd14e01b4f3ffa876596f5289dd8eab7f2 AS builder
+FROM alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870 AS builder
 
 # This hack is widely applied to avoid python printing issues in docker containers.
 # See: https://github.com/Docker-Hub-frolvlad/docker-alpine-python3/pull/13

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ In this stage we will use the console the manually run the ElectricEye ECS task,
 ## Supported Services and Checks
 
 These are the following services and checks perform by each Auditor, there are currently...
-- :boom: **548 Checks** :boom:
+- :boom: **550 Checks** :boom:
 - :exclamation: **100 AWS supported services/components** :exclamation:
 - :fire: **77 Auditors** :fire:
 
@@ -566,6 +566,7 @@ There are currently **62** supported response and remediation Playbooks with cov
 | Amazon_CognitoIdP_Auditor.py | Cognito Identity Pool | Does the Password policy comply with AWS CIS Foundations Benchmark |
 | Amazon_CognitoIdP_Auditor.py | Cognito Identity Pool | Cognito Temporary Password Age |
 | Amazon_CognitoIdP_Auditor.py | Cognito Identity Pool | Does the Identity pool enforce MFA |
+| Amazon_CognitoIdP_Auditor.py | Cognito Identity Pool | Is the Identity pool protected by WAF |
 | Amazon_DocumentDB_Auditor.py | DocumentDB Instance | Are Instances publicly accessible |
 | Amazon_DocumentDB_Auditor.py | DocumentDB Instance | Are Instance encrypted |
 | Amazon_DocumentDB_Auditor.py | DocumentDB Instance | Is audit logging enabled |
@@ -681,6 +682,7 @@ There are currently **62** supported response and remediation Playbooks with cov
 | Amazon_ELBv2_Auditor.py | ELBv2 (NLB) | Do NLBs with TLS listeners have access logging enabled |
 | Amazon_ELBv2_Auditor.py | ELBv2 (ALB) | Do ALBs have HTTP Desync protection enabled |
 | Amazon_ELBv2_Auditor.py | ELBv2 (ALB) | Do ALBs SGs allow access to non-Listener ports |
+| Amazon_ELBv2_Auditor.py | ELBv2 (ALB) | Ares ALBs protected by WAF |
 | Amazon_EMR_Auditor.py | EMR Cluster | Do clusters have a sec configuration attached |
 | Amazon_EMR_Auditor.py | EMR Cluster | Do cluster sec configs enforce encryption in transit |
 | Amazon_EMR_Auditor.py | EMR Cluster | Do cluster sec configs enforce encryption at rest for EMRFS |

--- a/cloudformation/ElectricEye_CFN.yaml
+++ b/cloudformation/ElectricEye_CFN.yaml
@@ -359,6 +359,7 @@ Resources:
                 - wafv2:ListWebACLs
                 - wafv2:GetLoggingConfiguration
                 - wafv2:GetWebACL
+                - wafv2:GetWebACLForResource
                 - cloudfront:ListDistributions
                 - sagemaker:ListModels
                 - ds:DescribeDirectories

--- a/eeauditor/auditors/aws/AWS_Backup_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_Backup_Auditor.py
@@ -151,7 +151,7 @@ def volume_backup_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for volumes in describe_volumes(cache)["Volumes"]:
         volumeId = str(volumes["VolumeId"])
-        volumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}/{volumeId}"
+        volumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}:volume/{volumeId}"
         # this is a passing check
         try:
             backup.describe_protected_resource(ResourceArn=volumeArn)

--- a/eeauditor/auditors/aws/AWS_Health_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_Health_Auditor.py
@@ -26,232 +26,226 @@ from check_register import CheckRegister
 registry = CheckRegister()
 
 # import boto3 clients
-health = boto3.client("health")
+sesh = boto3.session.Session()
+currentRegion = sesh.region_name
+if currentRegion != "us-east-1":
+    session = boto3.Session(region_name="us-east-1")
+    health = session.client("health")
+else:
+    health = boto3.client("health")
 
 @registry.register_check("health")
 def open_health_abuse_events_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Health.1] Open Abuse Events from AWS Health should be investigated"""
+    # ISO time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-    if awsRegion == 'us-east-1':
-        try:
-            response = health.describe_events(filter={"services": ["ABUSE"],"eventStatusCodes": ["open"]})
-            if response["events"]:
-                # this is a failing check
-                for event in response["events"]:
-                    eventArn = str(event["arn"])
-                    eventRegion = str(event["region"])
-                    finding = {
-                        "SchemaVersion": "2018-10-08",
-                        "Id": awsAccountId + eventArn + "/health-active-abuse-events-check",
-                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                        "GeneratorId": eventArn,
-                        "AwsAccountId": awsAccountId,
-                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                        "FirstObservedAt": iso8601Time,
-                        "CreatedAt": iso8601Time,
-                        "UpdatedAt": iso8601Time,
-                        "Severity": {"Label": "CRITICAL"},
-                        "Confidence": 99,
-                        "Title": "[Health.1] Open Abuse Events from AWS Health should be investigated",
-                        "Description": "There is an Active AWS Health Abuse event in the Region "
-                        + eventRegion
-                        + " with an ARN of "
-                        + eventArn
-                        + ". AWS Health Abuse events can come from the AWS Trust & Safety Team or AWS Security Operations team based on AWS scans and external reports, such as reports of your resources being used to distribute malware, pornography, or DDOS attacks. All Active events should be investigated, refer to the remediation section for more information on using the Health service.",
-                        "Remediation": {
-                            "Recommendation": {
-                                "Text": "To learn more about viewing and working with Health Events refer to the Getting started with the AWS Personal Health Dashboard section of the AWS Health User Guide.",
-                                "Url": "https://docs.aws.amazon.com/health/latest/ug/getting-started-phd.html#event-log"
-                            }
-                        },
-                        "ProductFields": {"Product Name": "ElectricEye"},
-                        "Resources": [
-                            {
-                                "Type": "AwsHealthEvent",
-                                "Id": eventArn,
-                                "Partition": awsPartition,
-                                "Region": awsRegion
-                            }
-                        ],
-                        "Compliance": {
-                            "Status": "FAILED",
-                            "RelatedRequirements": [
-                                "NIST CSF DE.AE-2",
-                                "NIST SP 800-53 AU-6",
-                                "NIST SP 800-53 CA-7",
-                                "NIST SP 800-53 IR-4",
-                                "NIST SP 800-53 SI-4",
-                                "AICPA TSC 7.2",
-                                "ISO 27001:2013 A.12.4.1",
-                                "ISO 27001:2013 A.16.1.1",
-                                "ISO 27001:2013 A.16.1.4"
-                            ]
-                        },
-                        "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE"
-                    }
-                    yield finding
-            else:
-                # if there is not an active Event the only thing to do would be to index on an Account
-                # which would break the feel of these findings and would not be able to be Archived
-                # so we will not write a finding at all
-                pass
-        except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'SubscriptionRequiredException':
-                print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')
-            else:
-                print(error)
-    else:
-        print('AWS Health Global endpoint is located in us-east-1')
+    try:
+        response = health.describe_events(filter={"services": ["ABUSE"],"eventStatusCodes": ["open"]})
+        if response["events"]:
+            # this is a failing check
+            for event in response["events"]:
+                eventArn = str(event["arn"])
+                eventRegion = str(event["region"])
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": awsAccountId + eventArn + "/health-active-abuse-events-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": eventArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "CRITICAL"},
+                    "Confidence": 99,
+                    "Title": "[Health.1] Open Abuse Events from AWS Health should be investigated",
+                    "Description": "There is an Active AWS Health Abuse event in the Region "
+                    + eventRegion
+                    + " with an ARN of "
+                    + eventArn
+                    + ". AWS Health Abuse events can come from the AWS Trust & Safety Team or AWS Security Operations team based on AWS scans and external reports, such as reports of your resources being used to distribute malware, pornography, or DDOS attacks. All Active events should be investigated, refer to the remediation section for more information on using the Health service.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "To learn more about viewing and working with Health Events refer to the Getting started with the AWS Personal Health Dashboard section of the AWS Health User Guide.",
+                            "Url": "https://docs.aws.amazon.com/health/latest/ug/getting-started-phd.html#event-log"
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsHealthEvent",
+                            "Id": eventArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "FAILED",
+                        "RelatedRequirements": [
+                            "NIST CSF DE.AE-2",
+                            "NIST SP 800-53 AU-6",
+                            "NIST SP 800-53 CA-7",
+                            "NIST SP 800-53 IR-4",
+                            "NIST SP 800-53 SI-4",
+                            "AICPA TSC 7.2",
+                            "ISO 27001:2013 A.12.4.1",
+                            "ISO 27001:2013 A.16.1.1",
+                            "ISO 27001:2013 A.16.1.4"
+                        ]
+                    },
+                    "Workflow": {"Status": "NEW"},
+                    "RecordState": "ACTIVE"
+                }
+                yield finding
+        else:
+            # if there is not an active Event the only thing to do would be to index on an Account
+            # which would break the feel of these findings and would not be able to be Archived
+            # so we will not write a finding at all
+            pass
+    except botocore.exceptions.ClientError as error:
+        if error.response['Error']['Code'] == 'SubscriptionRequiredException':
+            print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')
 
 @registry.register_check("health")
 def open_health_risk_events_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Health.2] Open Risk Events from AWS Health should be investigated"""
+    # ISO time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-    if awsRegion == 'us-east-1':
-        try:
-            response = health.describe_events(filter={"services": ["RISK"],"eventStatusCodes": ["open"]})
-            if response["events"]:
-                # this is a failing check
-                for event in response["events"]:
-                    eventArn = str(event["arn"])
-                    eventRegion = str(event["region"])
-                    finding = {
-                        "SchemaVersion": "2018-10-08",
-                        "Id": awsAccountId + eventArn + "/health-active-risk-events-check",
-                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                        "GeneratorId": eventArn,
-                        "AwsAccountId": awsAccountId,
-                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                        "FirstObservedAt": iso8601Time,
-                        "CreatedAt": iso8601Time,
-                        "UpdatedAt": iso8601Time,
-                        "Severity": {"Label": "CRITICAL"},
-                        "Confidence": 99,
-                        "Title": "[Health.2] Open Risk Events from AWS Health should be investigated",
-                        "Description": "There is an Active AWS Health Risk event in the Region "
-                        + eventRegion
-                        + " with an ARN of "
-                        + eventArn
-                        + ". AWS Health Risk events can come from the AWS Security Operations team based on AWS scans and external reports, such as reports of your resources being used to distribute malware, or having publicly exposed credentials on a public website (GitHub). All Active events should be investigated, refer to the remediation section for more information on using the Health service.",
-                        "Remediation": {
-                            "Recommendation": {
-                                "Text": "To learn more about viewing and working with Health Events refer to the Getting started with the AWS Personal Health Dashboard section of the AWS Health User Guide.",
-                                "Url": "https://docs.aws.amazon.com/health/latest/ug/getting-started-phd.html#event-log"
-                            }
-                        },
-                        "ProductFields": {"Product Name": "ElectricEye"},
-                        "Resources": [
-                            {
-                                "Type": "AwsHealthEvent",
-                                "Id": eventArn,
-                                "Partition": awsPartition,
-                                "Region": awsRegion
-                            }
-                        ],
-                        "Compliance": {
-                            "Status": "FAILED",
-                            "RelatedRequirements": [
-                                "NIST CSF DE.AE-2",
-                                "NIST SP 800-53 AU-6",
-                                "NIST SP 800-53 CA-7",
-                                "NIST SP 800-53 IR-4",
-                                "NIST SP 800-53 SI-4",
-                                "AICPA TSC 7.2",
-                                "ISO 27001:2013 A.12.4.1",
-                                "ISO 27001:2013 A.16.1.1",
-                                "ISO 27001:2013 A.16.1.4"
-                            ]
-                        },
-                        "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE"
-                    }
-                    yield finding
-            else:
-                # if there is not an active Event the only thing to do would be to index on an Account
-                # which would break the feel of these findings and would not be able to be Archived
-                # so we will not write a finding at all
-                pass
-        except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'SubscriptionRequiredException':
-                print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')
-            else:
-                print(error)
-    else:
-        print('AWS Health Global endpoint is located in us-east-1')
+    try:
+        response = health.describe_events(filter={"services": ["RISK"],"eventStatusCodes": ["open"]})
+        if response["events"]:
+            # this is a failing check
+            for event in response["events"]:
+                eventArn = str(event["arn"])
+                eventRegion = str(event["region"])
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": awsAccountId + eventArn + "/health-active-risk-events-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": eventArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "CRITICAL"},
+                    "Confidence": 99,
+                    "Title": "[Health.2] Open Risk Events from AWS Health should be investigated",
+                    "Description": "There is an Active AWS Health Risk event in the Region "
+                    + eventRegion
+                    + " with an ARN of "
+                    + eventArn
+                    + ". AWS Health Risk events can come from the AWS Security Operations team based on AWS scans and external reports, such as reports of your resources being used to distribute malware, or having publicly exposed credentials on a public website (GitHub). All Active events should be investigated, refer to the remediation section for more information on using the Health service.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "To learn more about viewing and working with Health Events refer to the Getting started with the AWS Personal Health Dashboard section of the AWS Health User Guide.",
+                            "Url": "https://docs.aws.amazon.com/health/latest/ug/getting-started-phd.html#event-log"
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsHealthEvent",
+                            "Id": eventArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "FAILED",
+                        "RelatedRequirements": [
+                            "NIST CSF DE.AE-2",
+                            "NIST SP 800-53 AU-6",
+                            "NIST SP 800-53 CA-7",
+                            "NIST SP 800-53 IR-4",
+                            "NIST SP 800-53 SI-4",
+                            "AICPA TSC 7.2",
+                            "ISO 27001:2013 A.12.4.1",
+                            "ISO 27001:2013 A.16.1.1",
+                            "ISO 27001:2013 A.16.1.4"
+                        ]
+                    },
+                    "Workflow": {"Status": "NEW"},
+                    "RecordState": "ACTIVE"
+                }
+                yield finding
+        else:
+            # if there is not an active Event the only thing to do would be to index on an Account
+            # which would break the feel of these findings and would not be able to be Archived
+            # so we will not write a finding at all
+            pass
+    except botocore.exceptions.ClientError as error:
+        if error.response['Error']['Code'] == 'SubscriptionRequiredException':
+            print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')
 
 @registry.register_check("health")
 def open_health_security_events_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Health.3] Open Security Events from AWS Health should be investigated"""
+    # ISO time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-    if awsRegion == 'us-east-1':
-        try:
-            response = health.describe_events(filter={"services": ["SECURITY"],"eventStatusCodes": ["open"]})
-            if response["events"]:
-                # this is a failing check
-                for event in response["events"]:
-                    eventArn = str(event["arn"])
-                    eventRegion = str(event["region"])
-                    finding = {
-                        "SchemaVersion": "2018-10-08",
-                        "Id": awsAccountId + eventArn + "/health-active-security-events-check",
-                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                        "GeneratorId": eventArn,
-                        "AwsAccountId": awsAccountId,
-                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                        "FirstObservedAt": iso8601Time,
-                        "CreatedAt": iso8601Time,
-                        "UpdatedAt": iso8601Time,
-                        "Severity": {"Label": "HIGH"},
-                        "Confidence": 99,
-                        "Title": "[Health.3] Open Security Events from AWS Health should be investigated",
-                        "Description": "There is an Active AWS Health Risk event in the Region "
-                        + eventRegion
-                        + " with an ARN of "
-                        + eventArn
-                        + ". AWS Health Risk events can come from the AWS Security Operations team or AWS Service teams due to security changes to specific accounts, services, or global changes. All Active events should be investigated, refer to the remediation section for more information on using the Health service.",
-                        "Remediation": {
-                            "Recommendation": {
-                                "Text": "To learn more about viewing and working with Health Events refer to the Getting started with the AWS Personal Health Dashboard section of the AWS Health User Guide.",
-                                "Url": "https://docs.aws.amazon.com/health/latest/ug/getting-started-phd.html#event-log"
-                            }
-                        },
-                        "ProductFields": {"Product Name": "ElectricEye"},
-                        "Resources": [
-                            {
-                                "Type": "AwsHealthEvent",
-                                "Id": eventArn,
-                                "Partition": awsPartition,
-                                "Region": awsRegion
-                            }
-                        ],
-                        "Compliance": {
-                            "Status": "FAILED",
-                            "RelatedRequirements": [
-                                "NIST CSF DE.AE-2",
-                                "NIST SP 800-53 AU-6",
-                                "NIST SP 800-53 CA-7",
-                                "NIST SP 800-53 IR-4",
-                                "NIST SP 800-53 SI-4",
-                                "AICPA TSC 7.2",
-                                "ISO 27001:2013 A.12.4.1",
-                                "ISO 27001:2013 A.16.1.1",
-                                "ISO 27001:2013 A.16.1.4"
-                            ]
-                        },
-                        "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE"
-                    }
-                    yield finding
-            else:
-                pass
-                # if there is not an active Event the only thing to do would be to index on an Account
-                # which would break the feel of these findings and would not be able to be Archived
-                # so we will not write a finding at all
-        except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'SubscriptionRequiredException':
-                print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')
-            else:
-                print(error)
-    else:
-        print('AWS Health Global endpoint is located in us-east-1')
+    try:
+        response = health.describe_events(filter={"services": ["SECURITY"],"eventStatusCodes": ["open"]})
+        if response["events"]:
+            # this is a failing check
+            for event in response["events"]:
+                eventArn = str(event["arn"])
+                eventRegion = str(event["region"])
+                finding = {
+                    "SchemaVersion": "2018-10-08",
+                    "Id": awsAccountId + eventArn + "/health-active-security-events-check",
+                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                    "GeneratorId": eventArn,
+                    "AwsAccountId": awsAccountId,
+                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                    "FirstObservedAt": iso8601Time,
+                    "CreatedAt": iso8601Time,
+                    "UpdatedAt": iso8601Time,
+                    "Severity": {"Label": "HIGH"},
+                    "Confidence": 99,
+                    "Title": "[Health.3] Open Security Events from AWS Health should be investigated",
+                    "Description": "There is an Active AWS Health Risk event in the Region "
+                    + eventRegion
+                    + " with an ARN of "
+                    + eventArn
+                    + ". AWS Health Risk events can come from the AWS Security Operations team or AWS Service teams due to security changes to specific accounts, services, or global changes. All Active events should be investigated, refer to the remediation section for more information on using the Health service.",
+                    "Remediation": {
+                        "Recommendation": {
+                            "Text": "To learn more about viewing and working with Health Events refer to the Getting started with the AWS Personal Health Dashboard section of the AWS Health User Guide.",
+                            "Url": "https://docs.aws.amazon.com/health/latest/ug/getting-started-phd.html#event-log"
+                        }
+                    },
+                    "ProductFields": {"Product Name": "ElectricEye"},
+                    "Resources": [
+                        {
+                            "Type": "AwsHealthEvent",
+                            "Id": eventArn,
+                            "Partition": awsPartition,
+                            "Region": awsRegion
+                        }
+                    ],
+                    "Compliance": {
+                        "Status": "FAILED",
+                        "RelatedRequirements": [
+                            "NIST CSF DE.AE-2",
+                            "NIST SP 800-53 AU-6",
+                            "NIST SP 800-53 CA-7",
+                            "NIST SP 800-53 IR-4",
+                            "NIST SP 800-53 SI-4",
+                            "AICPA TSC 7.2",
+                            "ISO 27001:2013 A.12.4.1",
+                            "ISO 27001:2013 A.16.1.1",
+                            "ISO 27001:2013 A.16.1.4"
+                        ]
+                    },
+                    "Workflow": {"Status": "NEW"},
+                    "RecordState": "ACTIVE"
+                }
+                yield finding
+        else:
+            pass
+            # if there is not an active Event the only thing to do would be to index on an Account
+            # which would break the feel of these findings and would not be able to be Archived
+            # so we will not write a finding at all
+    except botocore.exceptions.ClientError as error:
+        if error.response['Error']['Code'] == 'SubscriptionRequiredException':
+            print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')

--- a/eeauditor/auditors/aws/AWS_IAMRA_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_IAMRA_Auditor.py
@@ -20,8 +20,8 @@
 
 import boto3
 import datetime
-from check_register import CheckRegister
 import json
+from check_register import CheckRegister
 
 registry = CheckRegister()
 
@@ -51,126 +51,123 @@ def iamra_self_signed_trust_anchor_check(cache: dict, awsAccountId: str, awsRegi
     # ISO Time
     iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
     for ta in list_trust_anchors(cache)["trustAnchors"]:
-        try:
-            taArn = ta["trustAnchorArn"]
-            taId = ta["trustAnchorId"]
-            taCertSourceType = ta["source"]["sourceType"]
-            # This is a failing check
-            if taCertSourceType == "SELF_SIGNED_REPOSITORY":
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{taArn}/iamra-ta-self-signed-cert-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": taArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "MEDIUM"},
-                    "Confidence": 99,
-                    "Title": "[IAMRA.1] IAM Roles Anywhere Trust Anchors should not use self-signed certificates",
-                    "Description": f"IAM Roles Anywhere Trust Anchor {taId} uses a self-signed certificate. Self-signed certificates are a viable option for IAM Roles Anywhere Trust Anchors but are natively untrusted and can be easily manipulated by adveseraries. Consider using a trusted Certificate Authority or AWS Certificate Manager (ACM) Private Certificate Authority (PCA) to sign your X509 certificates in used by IAM Roles Anywhere. Refer to the remediation section if this behavior is not intended.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on IAMRA Trust Anchors refer to the Establish trust section of the AWS IAM Roles Anywhere User Guide",
-                            "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html#getting-started-step1"
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamRolesAnywhereTrustAnchor",
-                            "Id": taArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "Other": {
-                                    "TrustAnchorId": taId,
-                                    "TrustAnchorSourceType": taCertSourceType
-                                }
-                            },
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3"
-                        ]
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE"
-                }
-                yield finding
-            # this is a passing check
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{taArn}/iamra-ta-self-signed-cert-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": taArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "INFORMATIONAL"},
-                    "Confidence": 99,
-                    "Title": "[IAMRA.1] IAM Roles Anywhere Trust Anchors should not use self-signed certificates",
-                    "Description": f"IAM Roles Anywhere Trust Anchor {taId} does not use a self-signed certificate.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on IAMRA Trust Anchors refer to the Establish trust section of the AWS IAM Roles Anywhere User Guide",
-                            "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html#getting-started-step1"
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamRolesAnywhereTrustAnchor",
-                            "Id": taArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "Other": {
-                                    "TrustAnchorId": taId,
-                                    "TrustAnchorSourceType": taCertSourceType
-                                }
-                            },
-                        }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.DS-2",
-                            "NIST SP 800-53 SC-8",
-                            "NIST SP 800-53 SC-11",
-                            "NIST SP 800-53 SC-12",
-                            "AICPA TSC CC6.1",
-                            "ISO 27001:2013 A.8.2.3",
-                            "ISO 27001:2013 A.13.1.1",
-                            "ISO 27001:2013 A.13.2.1",
-                            "ISO 27001:2013 A.13.2.3",
-                            "ISO 27001:2013 A.14.1.2",
-                            "ISO 27001:2013 A.14.1.3"
-                        ]
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED"
-                }
-                yield finding
-        except Exception as e:
-            print(e)
+        taArn = ta["trustAnchorArn"]
+        taId = ta["trustAnchorId"]
+        taCertSourceType = ta["source"]["sourceType"]
+        # This is a failing check
+        if taCertSourceType == "SELF_SIGNED_REPOSITORY":
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{taArn}/iamra-ta-self-signed-cert-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": taArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "MEDIUM"},
+                "Confidence": 99,
+                "Title": "[IAMRA.1] IAM Roles Anywhere Trust Anchors should not use self-signed certificates",
+                "Description": f"IAM Roles Anywhere Trust Anchor {taId} uses a self-signed certificate. Self-signed certificates are a viable option for IAM Roles Anywhere Trust Anchors but are natively untrusted and can be easily manipulated by adveseraries. Consider using a trusted Certificate Authority or AWS Certificate Manager (ACM) Private Certificate Authority (PCA) to sign your X509 certificates in used by IAM Roles Anywhere. Refer to the remediation section if this behavior is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on IAMRA Trust Anchors refer to the Establish trust section of the AWS IAM Roles Anywhere User Guide",
+                        "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html#getting-started-step1"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamRolesAnywhereTrustAnchor",
+                        "Id": taArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "Other": {
+                                "TrustAnchorId": taId,
+                                "TrustAnchorSourceType": taCertSourceType
+                            }
+                        },
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.DS-2",
+                        "NIST SP 800-53 SC-8",
+                        "NIST SP 800-53 SC-11",
+                        "NIST SP 800-53 SC-12",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.2.3",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1",
+                        "ISO 27001:2013 A.13.2.3",
+                        "ISO 27001:2013 A.14.1.2",
+                        "ISO 27001:2013 A.14.1.3"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        # this is a passing check
+        else:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{taArn}/iamra-ta-self-signed-cert-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": taArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[IAMRA.1] IAM Roles Anywhere Trust Anchors should not use self-signed certificates",
+                "Description": f"IAM Roles Anywhere Trust Anchor {taId} does not use a self-signed certificate.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on IAMRA Trust Anchors refer to the Establish trust section of the AWS IAM Roles Anywhere User Guide",
+                        "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html#getting-started-step1"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamRolesAnywhereTrustAnchor",
+                        "Id": taArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "Other": {
+                                "TrustAnchorId": taId,
+                                "TrustAnchorSourceType": taCertSourceType
+                            }
+                        },
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.DS-2",
+                        "NIST SP 800-53 SC-8",
+                        "NIST SP 800-53 SC-11",
+                        "NIST SP 800-53 SC-12",
+                        "AICPA TSC CC6.1",
+                        "ISO 27001:2013 A.8.2.3",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1",
+                        "ISO 27001:2013 A.13.2.3",
+                        "ISO 27001:2013 A.14.1.2",
+                        "ISO 27001:2013 A.14.1.3"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
 
 @registry.register_check("rolesanywhere")
 def iamra_trust_anchor_crl_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
@@ -185,122 +182,119 @@ def iamra_trust_anchor_crl_check(cache: dict, awsAccountId: str, awsRegion: str,
         if crlTaArn not in iamraCrlTaArnList:
             iamraCrlTaArnList.append(crlTaArn)
     # Assess if the TA ARNs are associated with CRLs
-    try:
-        for ta in list_trust_anchors(cache)["trustAnchors"]:
-            taArn = ta["trustAnchorArn"]
-            taId = ta["trustAnchorId"]
-            # this is a failing check
-            if taArn not in iamraCrlTaArnList:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{taArn}/iamra-ta-crl-association-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": taArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "MEDIUM"},
-                    "Confidence": 99,
-                    "Title": "[IAMRA.2] IAM Roles Anywhere Trust Anchors should have a CRL associated",
-                    "Description": f"IAM Roles Anywhere Trust Anchor {taId} does not have a Certificate Revocation List (CRL) associated with it. Certificate revocation is supported through the use of imported certificate revocation lists (CRLs). Refer to the remediation section if this behavior is not intended.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on CRLs refer to the Revocation section of the AWS IAM Roles Anywhere User Guide",
-                            "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html#revocation"
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamRolesAnywhereTrustAnchor",
-                            "Id": taArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "Other": {
-                                    "TrustAnchorId": taId
-                                }
+    for ta in list_trust_anchors(cache)["trustAnchors"]:
+        taArn = ta["trustAnchorArn"]
+        taId = ta["trustAnchorId"]
+        # this is a failing check
+        if taArn not in iamraCrlTaArnList:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{taArn}/iamra-ta-crl-association-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": taArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "MEDIUM"},
+                "Confidence": 99,
+                "Title": "[IAMRA.2] IAM Roles Anywhere Trust Anchors should have a CRL associated",
+                "Description": f"IAM Roles Anywhere Trust Anchor {taId} does not have a Certificate Revocation List (CRL) associated with it. Certificate revocation is supported through the use of imported certificate revocation lists (CRLs). Refer to the remediation section if this behavior is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on CRLs refer to the Revocation section of the AWS IAM Roles Anywhere User Guide",
+                        "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html#revocation"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamRolesAnywhereTrustAnchor",
+                        "Id": taArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "Other": {
+                                "TrustAnchorId": taId
                             }
                         }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.MA-1",
-                            "NIST SP 800-53 MA-2",
-                            "NIST SP 800-53 MA-3",
-                            "NIST SP 800-53 MA-5",
-                            "NIST SP 800-53 MA-6",
-                            "AICPA TSC CC8.1",
-                            "ISO 27001:2013 A.11.1.2",
-                            "ISO 27001:2013 A.11.2.4",
-                            "ISO 27001:2013 A.11.2.5",
-                            "ISO 27001:2013 A.11.2.6"
-                        ]
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE"
-                }
-                yield finding
-            # this is a passing check
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": f"{taArn}/iamra-ta-crl-association-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": taArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "INFORMATIONAL"},
-                    "Confidence": 99,
-                    "Title": "[IAMRA.2] IAM Roles Anywhere Trust Anchors should have a CRL associated",
-                    "Description": f"IAM Roles Anywhere Trust Anchor {taId} has a Certificate Revocation List (CRL) associated with it.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on CRLs refer to the Revocation section of the AWS IAM Roles Anywhere User Guide",
-                            "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html#revocation"
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamRolesAnywhereTrustAnchor",
-                            "Id": taArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "Other": {
-                                    "TrustAnchorId": taId
-                                }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.MA-1",
+                        "NIST SP 800-53 MA-2",
+                        "NIST SP 800-53 MA-3",
+                        "NIST SP 800-53 MA-5",
+                        "NIST SP 800-53 MA-6",
+                        "AICPA TSC CC8.1",
+                        "ISO 27001:2013 A.11.1.2",
+                        "ISO 27001:2013 A.11.2.4",
+                        "ISO 27001:2013 A.11.2.5",
+                        "ISO 27001:2013 A.11.2.6"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        # this is a passing check
+        else:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{taArn}/iamra-ta-crl-association-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": taArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[IAMRA.2] IAM Roles Anywhere Trust Anchors should have a CRL associated",
+                "Description": f"IAM Roles Anywhere Trust Anchor {taId} has a Certificate Revocation List (CRL) associated with it.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on CRLs refer to the Revocation section of the AWS IAM Roles Anywhere User Guide",
+                        "Url": "https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html#revocation"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamRolesAnywhereTrustAnchor",
+                        "Id": taArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "Other": {
+                                "TrustAnchorId": taId
                             }
                         }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.MA-1",
-                            "NIST SP 800-53 MA-2",
-                            "NIST SP 800-53 MA-3",
-                            "NIST SP 800-53 MA-5",
-                            "NIST SP 800-53 MA-6",
-                            "AICPA TSC CC8.1",
-                            "ISO 27001:2013 A.11.1.2",
-                            "ISO 27001:2013 A.11.2.4",
-                            "ISO 27001:2013 A.11.2.5",
-                            "ISO 27001:2013 A.11.2.6"
-                        ]
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED"
-                }
-                yield finding
-    except Exception as e:
-        print(e)
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.MA-1",
+                        "NIST SP 800-53 MA-2",
+                        "NIST SP 800-53 MA-3",
+                        "NIST SP 800-53 MA-5",
+                        "NIST SP 800-53 MA-6",
+                        "AICPA TSC CC8.1",
+                        "ISO 27001:2013 A.11.1.2",
+                        "ISO 27001:2013 A.11.2.4",
+                        "ISO 27001:2013 A.11.2.5",
+                        "ISO 27001:2013 A.11.2.6"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
 
 @registry.register_check("rolesanywhere")
 def iamra_profiles_session_policy_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:

--- a/eeauditor/auditors/aws/AWS_IAM_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_IAM_Auditor.py
@@ -870,7 +870,6 @@ def cis_aws_foundation_benchmark_pw_policy_check(cache: dict, awsAccountId: str,
     """[IAM.6] The IAM password policy should meet or exceed the AWS CIS Foundations Benchmark standard"""
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-
     try:
         response = iam.get_account_password_policy()
         pwPolicy = response["PasswordPolicy"]
@@ -1092,81 +1091,187 @@ def cis_aws_foundation_benchmark_pw_policy_check(cache: dict, awsAccountId: str,
 @registry.register_check("iam")
 def server_certs_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[IAM.7] There should not be any server certificates stored in AWS IAM"""
-    try:
-        response = iam.list_server_certificates()
-        # ISO Time
-        iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-        if str(response["ServerCertificateMetadataList"]) != "[]":
-            finding = {
-                "SchemaVersion": "2018-10-08",
-                "Id": awsAccountId + "/server-x509-certs-check",
-                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                "GeneratorId": awsAccountId + "server-cert",
-                "AwsAccountId": awsAccountId,
-                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                "FirstObservedAt": iso8601Time,
-                "CreatedAt": iso8601Time,
-                "UpdatedAt": iso8601Time,
-                "Severity": {"Label": "MEDIUM"},
-                "Confidence": 99,
-                "Title": "[IAM.7] There should not be any server certificates stored in AWS IAM",
-                "Description": "There are server certificates stored in AWS IAM for the account "
-                + awsAccountId
-                + ". ACM is the preferred tool to provision, manage, and deploy your server certificates. With ACM you can request a certificate or deploy an existing ACM or external certificate to AWS resources. Certificates provided by ACM are free and automatically renew. Refer to the remediation instructions if this configuration is not intended.",
-                "Remediation": {
-                    "Recommendation": {
-                        "Text": "For information on server certificates refer to the Working with Server Certificates section of the AWS IAM User Guide",
-                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html",
-                    }
-                },
-                "ProductFields": {"Product Name": "ElectricEye"},
-                "Resources": [
-                    {
-                        "Type": "AwsAccount",
-                        "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
-                        "Partition": awsPartition,
-                        "Region": awsRegion,
-                    }
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    # use a list comprehension to find any server certs in IAM
+    # this is a failing check
+    if iam.list_server_certificates()["ServerCertificateMetadataList"]:
+        finding = {
+            "SchemaVersion": "2018-10-08",
+            "Id": awsAccountId + "/server-x509-certs-check",
+            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+            "GeneratorId": awsAccountId + "server-cert",
+            "AwsAccountId": awsAccountId,
+            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+            "FirstObservedAt": iso8601Time,
+            "CreatedAt": iso8601Time,
+            "UpdatedAt": iso8601Time,
+            "Severity": {"Label": "MEDIUM"},
+            "Confidence": 99,
+            "Title": "[IAM.7] There should not be any server certificates stored in AWS IAM",
+            "Description": "There are server certificates stored in AWS IAM for the account "
+            + awsAccountId
+            + ". ACM is the preferred tool to provision, manage, and deploy your server certificates. With ACM you can request a certificate or deploy an existing ACM or external certificate to AWS resources. Certificates provided by ACM are free and automatically renew. Refer to the remediation instructions if this configuration is not intended.",
+            "Remediation": {
+                "Recommendation": {
+                    "Text": "For information on server certificates refer to the Working with Server Certificates section of the AWS IAM User Guide",
+                    "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html",
+                }
+            },
+            "ProductFields": {"Product Name": "ElectricEye"},
+            "Resources": [
+                {
+                    "Type": "AwsAccount",
+                    "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
+                    "Partition": awsPartition,
+                    "Region": awsRegion,
+                }
+            ],
+            "Compliance": {
+                "Status": "FAILED",
+                "RelatedRequirements": [
+                    "NIST CSF PR.AC-1",
+                    "NIST SP 800-53 AC-1",
+                    "NIST SP 800-53 AC-2",
+                    "NIST SP 800-53 IA-1",
+                    "NIST SP 800-53 IA-2",
+                    "NIST SP 800-53 IA-3",
+                    "NIST SP 800-53 IA-4",
+                    "NIST SP 800-53 IA-5",
+                    "NIST SP 800-53 IA-6",
+                    "NIST SP 800-53 IA-7",
+                    "NIST SP 800-53 IA-8",
+                    "NIST SP 800-53 IA-9",
+                    "NIST SP 800-53 IA-10",
+                    "NIST SP 800-53 IA-11",
+                    "AICPA TSC CC6.1",
+                    "AICPA TSC CC6.2",
+                    "ISO 27001:2013 A.9.2.1",
+                    "ISO 27001:2013 A.9.2.2",
+                    "ISO 27001:2013 A.9.2.3",
+                    "ISO 27001:2013 A.9.2.4",
+                    "ISO 27001:2013 A.9.2.6",
+                    "ISO 27001:2013 A.9.3.1",
+                    "ISO 27001:2013 A.9.4.2",
+                    "ISO 27001:2013 A.9.4.3",
                 ],
-                "Compliance": {
-                    "Status": "FAILED",
-                    "RelatedRequirements": [
-                        "NIST CSF PR.AC-1",
-                        "NIST SP 800-53 AC-1",
-                        "NIST SP 800-53 AC-2",
-                        "NIST SP 800-53 IA-1",
-                        "NIST SP 800-53 IA-2",
-                        "NIST SP 800-53 IA-3",
-                        "NIST SP 800-53 IA-4",
-                        "NIST SP 800-53 IA-5",
-                        "NIST SP 800-53 IA-6",
-                        "NIST SP 800-53 IA-7",
-                        "NIST SP 800-53 IA-8",
-                        "NIST SP 800-53 IA-9",
-                        "NIST SP 800-53 IA-10",
-                        "NIST SP 800-53 IA-11",
-                        "AICPA TSC CC6.1",
-                        "AICPA TSC CC6.2",
-                        "ISO 27001:2013 A.9.2.1",
-                        "ISO 27001:2013 A.9.2.2",
-                        "ISO 27001:2013 A.9.2.3",
-                        "ISO 27001:2013 A.9.2.4",
-                        "ISO 27001:2013 A.9.2.6",
-                        "ISO 27001:2013 A.9.3.1",
-                        "ISO 27001:2013 A.9.4.2",
-                        "ISO 27001:2013 A.9.4.3",
-                    ],
-                },
-                "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
-            }
-            yield finding
-        else:
+            },
+            "Workflow": {"Status": "NEW"},
+            "RecordState": "ACTIVE",
+        }
+        yield finding
+    # this is a passing check
+    else:
+        finding = {
+            "SchemaVersion": "2018-10-08",
+            "Id": awsAccountId + "/server-x509-certs-check",
+            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+            "GeneratorId": awsAccountId + "server-cert",
+            "AwsAccountId": awsAccountId,
+            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+            "FirstObservedAt": iso8601Time,
+            "CreatedAt": iso8601Time,
+            "UpdatedAt": iso8601Time,
+            "Severity": {"Label": "INFORMATIONAL"},
+            "Confidence": 99,
+            "Title": "[IAM.7] There should not be any server certificates stored in AWS IAM",
+            "Description": "There are not server certificates stored in AWS IAM for the account "
+            + awsAccountId
+            + ".",
+            "Remediation": {
+                "Recommendation": {
+                    "Text": "For information on server certificates refer to the Working with Server Certificates section of the AWS IAM User Guide",
+                    "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html",
+                }
+            },
+            "ProductFields": {"Product Name": "ElectricEye"},
+            "Resources": [
+                {
+                    "Type": "AwsAccount",
+                    "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
+                    "Partition": awsPartition,
+                    "Region": awsRegion,
+                }
+            ],
+            "Compliance": {
+                "Status": "PASSED",
+                "RelatedRequirements": [
+                    "NIST CSF PR.AC-1",
+                    "NIST SP 800-53 AC-1",
+                    "NIST SP 800-53 AC-2",
+                    "NIST SP 800-53 IA-1",
+                    "NIST SP 800-53 IA-2",
+                    "NIST SP 800-53 IA-3",
+                    "NIST SP 800-53 IA-4",
+                    "NIST SP 800-53 IA-5",
+                    "NIST SP 800-53 IA-6",
+                    "NIST SP 800-53 IA-7",
+                    "NIST SP 800-53 IA-8",
+                    "NIST SP 800-53 IA-9",
+                    "NIST SP 800-53 IA-10",
+                    "NIST SP 800-53 IA-11",
+                    "AICPA TSC CC6.1",
+                    "AICPA TSC CC6.2",
+                    "ISO 27001:2013 A.9.2.1",
+                    "ISO 27001:2013 A.9.2.2",
+                    "ISO 27001:2013 A.9.2.3",
+                    "ISO 27001:2013 A.9.2.4",
+                    "ISO 27001:2013 A.9.2.6",
+                    "ISO 27001:2013 A.9.3.1",
+                    "ISO 27001:2013 A.9.4.2",
+                    "ISO 27001:2013 A.9.4.3",
+                ],
+            },
+            "Workflow": {"Status": "RESOLVED"},
+            "RecordState": "ARCHIVED",
+        }
+        yield finding
+
+@registry.register_check("iam")
+def iam_created_managed_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[IAM.8] Managed policies should follow least privilege principles"""
+    # ISO time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for mpolicy in iam.list_policies(Scope='Local')['Policies']:
+        policyArn = mpolicy['Arn']
+        versionId = mpolicy['DefaultVersionId']
+        policyDocument = iam.get_policy_version(
+            PolicyArn=policyArn,
+            VersionId=versionId
+        )['PolicyVersion']['Document']
+        #handle policies docs returned as strings
+        if type(policyDocument) == str:
+            policyDocument = json.loads(policyDocument)
+
+        leastPrivilegeRating = 'passing'
+        for statement in policyDocument['Statement']:
+            if statement["Effect"] == 'Allow':
+                if statement.get('Condition') == None: 
+                    # action structure could be a string or a list
+                    if type(statement['Action']) == list: 
+                        if len(['True' for x in statement['Action'] if ":*" in x or '*' == x]) > 0:
+                            if type(statement['Resource']) == str and statement['Resource'] == '*':
+                                leastPrivilegeRating = 'failedHigh'
+                                # Means that an initial failure will not be overwritten by a lower finding later
+                                next
+                            elif type(statement['Resource']) == list: 
+                                leastPrivilegeRating = 'failedLow'
+
+                    # Single action in a statement
+                    elif type(statement['Action']) == str:
+                        if ":*" in statement['Action'] or statement['Action'] == '*':
+                            if type(statement['Resource']) == str and statement['Resource'] == '*':
+                                leastPrivilegeRating = 'failedHigh'
+                                # Means that an initial failure will not be overwritten by a lower finding later
+                                next
+                            elif type(statement['Resource']) == list: 
+                                leastPrivilegeRating = 'failedLow'
+        if leastPrivilegeRating == 'passing':
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": awsAccountId + "/server-x509-certs-check",
+                "Id": f"{policyArn}/mpolicy_least_priv",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                "GeneratorId": awsAccountId + "server-cert",
+                "GeneratorId": policyArn,
                 "AwsAccountId": awsAccountId,
                 "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                 "FirstObservedAt": iso8601Time,
@@ -1174,74 +1279,178 @@ def server_certs_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartit
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[IAM.7] There should not be any server certificates stored in AWS IAM",
-                "Description": "There are not server certificates stored in AWS IAM for the account "
-                + awsAccountId
-                + ".",
+                "Title": "[IAM.8] Managed policies should follow least privilege principles",
+                "Description": f"The customer managed policy {policyArn} is following least privilege principles.",
                 "Remediation": {
                     "Recommendation": {
-                        "Text": "For information on server certificates refer to the Working with Server Certificates section of the AWS IAM User Guide",
-                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html",
+                        "Text": "For information on IAM least privilege refer to the Controlling access section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html",
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
                 "Resources": [
                     {
-                        "Type": "AwsAccount",
-                        "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
+                        "Type": "AwsIamPolicy",
+                        "Id": policyArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
+                        "Details": {
+                            "AwsIamPolicy": {
+                                "DefaultVersionId": versionId
+                            }
+                        }
                     }
                 ],
                 "Compliance": {
                     "Status": "PASSED",
                     "RelatedRequirements": [
-                        "NIST CSF PR.AC-1",
+                        "NIST CSF PR.AC-3",
                         "NIST SP 800-53 AC-1",
-                        "NIST SP 800-53 AC-2",
-                        "NIST SP 800-53 IA-1",
-                        "NIST SP 800-53 IA-2",
-                        "NIST SP 800-53 IA-3",
-                        "NIST SP 800-53 IA-4",
-                        "NIST SP 800-53 IA-5",
-                        "NIST SP 800-53 IA-6",
-                        "NIST SP 800-53 IA-7",
-                        "NIST SP 800-53 IA-8",
-                        "NIST SP 800-53 IA-9",
-                        "NIST SP 800-53 IA-10",
-                        "NIST SP 800-53 IA-11",
-                        "AICPA TSC CC6.1",
-                        "AICPA TSC CC6.2",
-                        "ISO 27001:2013 A.9.2.1",
-                        "ISO 27001:2013 A.9.2.2",
-                        "ISO 27001:2013 A.9.2.3",
-                        "ISO 27001:2013 A.9.2.4",
-                        "ISO 27001:2013 A.9.2.6",
-                        "ISO 27001:2013 A.9.3.1",
-                        "ISO 27001:2013 A.9.4.2",
-                        "ISO 27001:2013 A.9.4.3",
+                        "NIST SP 800-53 AC-17",
+                        "NIST SP 800-53 AC-19",
+                        "NIST SP 800-53 AC-20",
+                        "NIST SP 800-53 SC-15",
+                        "AICPA TSC CC6.6",
+                        "ISO 27001:2013 A.6.2.1",
+                        "ISO 27001:2013 A.6.2.2",
+                        "ISO 27001:2013 A.11.2.6",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1"
                     ],
                 },
                 "Workflow": {"Status": "RESOLVED"},
                 "RecordState": "ARCHIVED",
             }
             yield finding
-    except Exception as e:
-        print(e)
+        elif leastPrivilegeRating == 'failedLow':
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{policyArn}/mpolicy_least_priv",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": policyArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "LOW"},
+                "Confidence": 99,
+                "Title": "[IAM.8] Managed policies should follow least privilege principles",
+                "Description": f"The customer managed policy {policyArn} is not following least privilege principles and has been rated: {leastPrivilegeRating}. Refer to the remediation section if this behavior is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on IAM least privilege refer to the Controlling access section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamPolicy",
+                        "Id": policyArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsIamPolicy": {
+                                "DefaultVersionId": versionId
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-3",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-17",
+                        "NIST SP 800-53 AC-19",
+                        "NIST SP 800-53 AC-20",
+                        "NIST SP 800-53 SC-15",
+                        "AICPA TSC CC6.6",
+                        "ISO 27001:2013 A.6.2.1",
+                        "ISO 27001:2013 A.6.2.2",
+                        "ISO 27001:2013 A.11.2.6",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1"
+                    ],
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE",
+            }
+            yield finding
+        elif leastPrivilegeRating == 'failedHigh':
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{policyArn}/mpolicy_least_priv",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": policyArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "HIGH"},
+                "Confidence": 99,
+                "Title": "[IAM.8] Managed policies should follow least privilege principles",
+                "Description": f"The customer managed policy {policyArn} is not following least privilege principles and has been rated: {leastPrivilegeRating}. Refer to the remediation section if this behavior is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on IAM least privilege refer to the Controlling access section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamPolicy",
+                        "Id": policyArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsIamPolicy": {
+                                "DefaultVersionId": versionId
+                            }
+                        }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-3",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-17",
+                        "NIST SP 800-53 AC-19",
+                        "NIST SP 800-53 AC-20",
+                        "NIST SP 800-53 SC-15",
+                        "AICPA TSC CC6.6",
+                        "ISO 27001:2013 A.6.2.1",
+                        "ISO 27001:2013 A.6.2.2",
+                        "ISO 27001:2013 A.11.2.6",
+                        "ISO 27001:2013 A.13.1.1",
+                        "ISO 27001:2013 A.13.2.1"
+                    ],
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE",
+            }
+            yield finding
 
 @registry.register_check("iam")
-def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[IAM.8] Managed policies should follow least privilege principles"""
-    try:
-        policies = iam.list_policies(Scope='Local')
-        for mngd_policy in policies['Policies']:
-            policyArn = mngd_policy['Arn']
-            versionId = mngd_policy['DefaultVersionId']
+def iam_user_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[IAM.9] User inline policies should follow least privilege principles"""
+    for users in list_users(cache)["Users"]:
+        userArn = users['Arn']
+        userName = users['UserName']
 
-            policyDocument = iam.get_policy_version(
-                PolicyArn=policyArn,
-                VersionId=versionId
-            )['PolicyVersion']['Document']
+        policyNames = iam.list_user_policies(
+            UserName=userName
+        )['PolicyNames']
+        for policyName in policyNames:
+            policyDocument = iam.get_user_policy(
+                UserName=userName,
+                PolicyName=policyName
+            )['PolicyDocument']
+
             #handle policies docs returned as strings
             if type(policyDocument) == str:
                 policyDocument = json.loads(policyDocument)
@@ -1254,29 +1463,29 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                         if type(statement['Action']) == list: 
                             if len(['True' for x in statement['Action'] if ":*" in x or '*' == x]) > 0:
                                 if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                    leastPrivilegeRating = 'failed_high'
+                                    leastPrivilegeRating = 'failedHigh'
                                     # Means that an initial failure will not be overwritten by a lower finding later
                                     next
                                 elif type(statement['Resource']) == list: 
-                                    leastPrivilegeRating = 'failed_low'
+                                    leastPrivilegeRating = 'failedLow'
 
                         # Single action in a statement
                         elif type(statement['Action']) == str:
                             if ":*" in statement['Action'] or statement['Action'] == '*':
                                 if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                    leastPrivilegeRating = 'failed_high'
+                                    leastPrivilegeRating = 'failedHigh'
                                     # Means that an initial failure will not be overwritten by a lower finding later
                                     next
                                 elif type(statement['Resource']) == list: 
-                                    leastPrivilegeRating = 'failed_low'
+                                    leastPrivilegeRating = 'failedLow'
 
             iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
             if leastPrivilegeRating == 'passing':
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": f"{policyArn}/mngd_policy_least_priv",
+                    "Id": f"{userArn}/user_policy_least_priv",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": policyArn,
+                    "GeneratorId": userArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -1284,24 +1493,29 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                     "UpdatedAt": iso8601Time,
                     "Severity": {"Label": "INFORMATIONAL"},
                     "Confidence": 99,
-                    "Title": "[IAM.8] Managed policies should follow least privilege principles",
-                    "Description": f"The customer managed policy {policyArn} is following least privilege principles.",
+                    "Title": "[IAM.9] User inline policies should follow least privilege principles",
+                    "Description": f"The user {userArn} inline policy {policyName} is following least privilege principles.",
                     "Remediation": {
                         "Recommendation": {
-                            "Text": "For information on IAM least privilege refer to the Controlling access section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html",
+                            "Text": "For information on IAM least privilege refer to the inline policy section of the AWS IAM User Guide",
+                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies",
                         }
                     },
                     "ProductFields": {"Product Name": "ElectricEye"},
                     "Resources": [
                         {
-                            "Type": "AwsIamPolicy",
-                            "Id": policyArn,
+                            "Type": "AwsIamUser",
+                            "Id": userArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
                             "Details": {
-                                "AwsIamPolicy": {
-                                    "DefaultVersionId": versionId
+                                "AwsIamUser": {
+                                    "UserPolicyList": [
+                                        {
+                                            "PolicyName": policyName
+                                        }
+                                    ],
+                                    "UserName": userName
                                 }
                             }
                         }
@@ -1327,12 +1541,12 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                     "RecordState": "ARCHIVED",
                 }
                 yield finding
-            elif leastPrivilegeRating == 'failed_low':
+            elif leastPrivilegeRating == 'failedLow':
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": f"{policyArn}/mngd_policy_least_priv",
+                    "Id": f"{userArn}/user_policy_least_priv",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": policyArn,
+                    "GeneratorId": userArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -1340,24 +1554,29 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                     "UpdatedAt": iso8601Time,
                     "Severity": {"Label": "LOW"},
                     "Confidence": 99,
-                    "Title": "[IAM.8] Managed policies should follow least privilege principles",
-                    "Description": f"The customer managed policy {policyArn} is not following least privilege principles and has been rated: {leastPrivilegeRating}. Refer to the remediation section if this behavior is not intended.",
+                    "Title": "[IAM.9] User inline policies should follow least privilege principles",
+                    "Description": f"The user {userArn} inline policy {policyName} is not following least privilege principles. Refer to the remediation section if this behavior is not intended.",
                     "Remediation": {
                         "Recommendation": {
-                            "Text": "For information on IAM least privilege refer to the Controlling access section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html",
+                            "Text": "For information on IAM least privilege refer to the inline policy section of the AWS IAM User Guide",
+                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies",
                         }
                     },
                     "ProductFields": {"Product Name": "ElectricEye"},
                     "Resources": [
                         {
-                            "Type": "AwsIamPolicy",
-                            "Id": policyArn,
+                            "Type": "AwsIamUser",
+                            "Id": userArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
                             "Details": {
-                                "AwsIamPolicy": {
-                                    "DefaultVersionId": versionId
+                                "AwsIamUser": {
+                                    "UserPolicyList": [
+                                        {
+                                            "PolicyName": policyName
+                                        }
+                                    ],
+                                    "UserName": userName
                                 }
                             }
                         }
@@ -1383,12 +1602,12 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                     "RecordState": "ACTIVE",
                 }
                 yield finding
-            elif leastPrivilegeRating == 'failed_high':
+            elif leastPrivilegeRating == 'failedHigh':
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": f"{policyArn}/mngd_policy_least_priv",
+                    "Id": f"{userArn}/user_policy_least_priv",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": policyArn,
+                    "GeneratorId": userArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -1396,24 +1615,29 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                     "UpdatedAt": iso8601Time,
                     "Severity": {"Label": "HIGH"},
                     "Confidence": 99,
-                    "Title": "[IAM.8] Managed policies should follow least privilege principles",
-                    "Description": f"The customer managed policy {policyArn} is not following least privilege principles and has been rated: {leastPrivilegeRating}. Refer to the remediation section if this behavior is not intended.",
+                    "Title": "[IAM.9] User inline policies should follow least privilege principles",
+                    "Description": f"The user {userArn} inline policy {policyName} is not following least privilege principles. Refer to the remediation section if this behavior is not intended.",
                     "Remediation": {
                         "Recommendation": {
-                            "Text": "For information on IAM least privilege refer to the Controlling access section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html",
+                            "Text": "For information on IAM least privilege refer to the inline policy section of the AWS IAM User Guide",
+                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies",
                         }
                     },
                     "ProductFields": {"Product Name": "ElectricEye"},
                     "Resources": [
                         {
-                            "Type": "AwsIamPolicy",
-                            "Id": policyArn,
+                            "Type": "AwsIamUser",
+                            "Id": userArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
                             "Details": {
-                                "AwsIamPolicy": {
-                                    "DefaultVersionId": versionId
+                                "AwsIamUser": {
+                                    "UserPolicyList": [
+                                        {
+                                            "PolicyName": policyName
+                                        }
+                                    ],
+                                    "UserName": userName
                                 }
                             }
                         }
@@ -1439,240 +1663,6 @@ def iam_mngd_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                     "RecordState": "ACTIVE",
                 }
                 yield finding
-    except: 
-        pass
-
-@registry.register_check("iam")
-def iam_user_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[IAM.9] User inline policies should follow least privilege principles"""
-    try:
-        for users in list_users(cache)["Users"]:
-            userArn = users['Arn']
-            userName = users['UserName']
-
-            policyNames = iam.list_user_policies(
-                UserName=userName
-            )['PolicyNames']
-            for policyName in policyNames:
-                policyDocument = iam.get_user_policy(
-                    UserName=userName,
-                    PolicyName=policyName
-                )['PolicyDocument']
-
-                #handle policies docs returned as strings
-                if type(policyDocument) == str:
-                    policyDocument = json.loads(policyDocument)
-
-                leastPrivilegeRating = 'passing'
-                for statement in policyDocument['Statement']:
-                    if statement["Effect"] == 'Allow':
-                        if statement.get('Condition') == None: 
-                            # action structure could be a string or a list
-                            if type(statement['Action']) == list: 
-                                if len(['True' for x in statement['Action'] if ":*" in x or '*' == x]) > 0:
-                                    if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                        leastPrivilegeRating = 'failed_high'
-                                        # Means that an initial failure will not be overwritten by a lower finding later
-                                        next
-                                    elif type(statement['Resource']) == list: 
-                                        leastPrivilegeRating = 'failed_low'
-
-                            # Single action in a statement
-                            elif type(statement['Action']) == str:
-                                if ":*" in statement['Action'] or statement['Action'] == '*':
-                                    if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                        leastPrivilegeRating = 'failed_high'
-                                        # Means that an initial failure will not be overwritten by a lower finding later
-                                        next
-                                    elif type(statement['Resource']) == list: 
-                                        leastPrivilegeRating = 'failed_low'
-
-                iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-                if leastPrivilegeRating == 'passing':
-                    finding = {
-                        "SchemaVersion": "2018-10-08",
-                        "Id": f"{userArn}/user_policy_least_priv",
-                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                        "GeneratorId": userArn,
-                        "AwsAccountId": awsAccountId,
-                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                        "FirstObservedAt": iso8601Time,
-                        "CreatedAt": iso8601Time,
-                        "UpdatedAt": iso8601Time,
-                        "Severity": {"Label": "INFORMATIONAL"},
-                        "Confidence": 99,
-                        "Title": "[IAM.9] User inline policies should follow least privilege principles",
-                        "Description": f"The user {userArn} inline policy {policyName} is following least privilege principles.",
-                        "Remediation": {
-                            "Recommendation": {
-                                "Text": "For information on IAM least privilege refer to the inline policy section of the AWS IAM User Guide",
-                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies",
-                            }
-                        },
-                        "ProductFields": {"Product Name": "ElectricEye"},
-                        "Resources": [
-                            {
-                                "Type": "AwsIamUser",
-                                "Id": userArn,
-                                "Partition": awsPartition,
-                                "Region": awsRegion,
-                                "Details": {
-                                    "AwsIamUser": {
-                                        "UserPolicyList": [
-                                            {
-                                                "PolicyName": policyName
-                                            }
-                                        ],
-                                        "UserName": userName
-                                    }
-                                }
-                            }
-                        ],
-                        "Compliance": {
-                            "Status": "PASSED",
-                            "RelatedRequirements": [
-                                "NIST CSF PR.AC-3",
-                                "NIST SP 800-53 AC-1",
-                                "NIST SP 800-53 AC-17",
-                                "NIST SP 800-53 AC-19",
-                                "NIST SP 800-53 AC-20",
-                                "NIST SP 800-53 SC-15",
-                                "AICPA TSC CC6.6",
-                                "ISO 27001:2013 A.6.2.1",
-                                "ISO 27001:2013 A.6.2.2",
-                                "ISO 27001:2013 A.11.2.6",
-                                "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1"
-                            ],
-                        },
-                        "Workflow": {"Status": "RESOLVED"},
-                        "RecordState": "ARCHIVED",
-                    }
-                    yield finding
-                elif leastPrivilegeRating == 'failed_low':
-                    finding = {
-                        "SchemaVersion": "2018-10-08",
-                        "Id": f"{userArn}/user_policy_least_priv",
-                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                        "GeneratorId": userArn,
-                        "AwsAccountId": awsAccountId,
-                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                        "FirstObservedAt": iso8601Time,
-                        "CreatedAt": iso8601Time,
-                        "UpdatedAt": iso8601Time,
-                        "Severity": {"Label": "LOW"},
-                        "Confidence": 99,
-                        "Title": "[IAM.9] User inline policies should follow least privilege principles",
-                        "Description": f"The user {userArn} inline policy {policyName} is not following least privilege principles. Refer to the remediation section if this behavior is not intended.",
-                        "Remediation": {
-                            "Recommendation": {
-                                "Text": "For information on IAM least privilege refer to the inline policy section of the AWS IAM User Guide",
-                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies",
-                            }
-                        },
-                        "ProductFields": {"Product Name": "ElectricEye"},
-                        "Resources": [
-                            {
-                                "Type": "AwsIamUser",
-                                "Id": userArn,
-                                "Partition": awsPartition,
-                                "Region": awsRegion,
-                                "Details": {
-                                    "AwsIamUser": {
-                                        "UserPolicyList": [
-                                            {
-                                                "PolicyName": policyName
-                                            }
-                                        ],
-                                        "UserName": userName
-                                    }
-                                }
-                            }
-                        ],
-                        "Compliance": {
-                            "Status": "FAILED",
-                            "RelatedRequirements": [
-                                "NIST CSF PR.AC-3",
-                                "NIST SP 800-53 AC-1",
-                                "NIST SP 800-53 AC-17",
-                                "NIST SP 800-53 AC-19",
-                                "NIST SP 800-53 AC-20",
-                                "NIST SP 800-53 SC-15",
-                                "AICPA TSC CC6.6",
-                                "ISO 27001:2013 A.6.2.1",
-                                "ISO 27001:2013 A.6.2.2",
-                                "ISO 27001:2013 A.11.2.6",
-                                "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1"
-                            ],
-                        },
-                        "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
-                    }
-                    yield finding
-                elif leastPrivilegeRating == 'failed_high':
-                    finding = {
-                        "SchemaVersion": "2018-10-08",
-                        "Id": f"{userArn}/user_policy_least_priv",
-                        "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                        "GeneratorId": userArn,
-                        "AwsAccountId": awsAccountId,
-                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                        "FirstObservedAt": iso8601Time,
-                        "CreatedAt": iso8601Time,
-                        "UpdatedAt": iso8601Time,
-                        "Severity": {"Label": "HIGH"},
-                        "Confidence": 99,
-                        "Title": "[IAM.9] User inline policies should follow least privilege principles",
-                        "Description": f"The user {userArn} inline policy {policyName} is not following least privilege principles. Refer to the remediation section if this behavior is not intended.",
-                        "Remediation": {
-                            "Recommendation": {
-                                "Text": "For information on IAM least privilege refer to the inline policy section of the AWS IAM User Guide",
-                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies",
-                            }
-                        },
-                        "ProductFields": {"Product Name": "ElectricEye"},
-                        "Resources": [
-                            {
-                                "Type": "AwsIamUser",
-                                "Id": userArn,
-                                "Partition": awsPartition,
-                                "Region": awsRegion,
-                                "Details": {
-                                    "AwsIamUser": {
-                                        "UserPolicyList": [
-                                            {
-                                                "PolicyName": policyName
-                                            }
-                                        ],
-                                        "UserName": userName
-                                    }
-                                }
-                            }
-                        ],
-                        "Compliance": {
-                            "Status": "FAILED",
-                            "RelatedRequirements": [
-                                "NIST CSF PR.AC-3",
-                                "NIST SP 800-53 AC-1",
-                                "NIST SP 800-53 AC-17",
-                                "NIST SP 800-53 AC-19",
-                                "NIST SP 800-53 AC-20",
-                                "NIST SP 800-53 SC-15",
-                                "AICPA TSC CC6.6",
-                                "ISO 27001:2013 A.6.2.1",
-                                "ISO 27001:2013 A.6.2.2",
-                                "ISO 27001:2013 A.11.2.6",
-                                "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1"
-                            ],
-                        },
-                        "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
-                    }
-                    yield finding
-    except: 
-        pass
 
 @registry.register_check("iam")
 def iam_group_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
@@ -1704,21 +1694,21 @@ def iam_group_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion:
                             if type(statement['Action']) == list: 
                                 if len(['True' for x in statement['Action'] if ":*" in x or '*' == x]) > 0:
                                     if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                        leastPrivilegeRating = 'failed_high'
+                                        leastPrivilegeRating = 'failedHigh'
                                         # Means that an initial failure will not be overwritten by a lower finding later
                                         next
                                     elif type(statement['Resource']) == list: 
-                                        leastPrivilegeRating = 'failed_low'
+                                        leastPrivilegeRating = 'failedLow'
 
                             # Single action in a statement
                             elif type(statement['Action']) == str:
                                 if ":*" in statement['Action'] or statement['Action'] == '*':
                                     if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                        leastPrivilegeRating = 'failed_high'
+                                        leastPrivilegeRating = 'failedHigh'
                                         # Means that an initial failure will not be overwritten by a lower finding later
                                         next
                                     elif type(statement['Resource']) == list: 
-                                        leastPrivilegeRating = 'failed_low'
+                                        leastPrivilegeRating = 'failedLow'
 
                 iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
                 if leastPrivilegeRating == 'passing':
@@ -1782,7 +1772,7 @@ def iam_group_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion:
                         "RecordState": "ARCHIVED",
                     }
                     yield finding
-                elif leastPrivilegeRating == 'failed_low':
+                elif leastPrivilegeRating == 'failedLow':
                     finding = {
                         "SchemaVersion": "2018-10-08",
                         "Id": f"{groupArn}/group_policy_least_priv",
@@ -1843,7 +1833,7 @@ def iam_group_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion:
                         "RecordState": "ACTIVE",
                     }
                     yield finding
-                elif leastPrivilegeRating == 'failed_high':
+                elif leastPrivilegeRating == 'failedHigh':
                     finding = {
                         "SchemaVersion": "2018-10-08",
                         "Id": f"{groupArn}/group_policy_least_priv",
@@ -1938,21 +1928,21 @@ def iam_role_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                             if type(statement['Action']) == list: 
                                 if len(['True' for x in statement['Action'] if ":*" in x or '*' == x]) > 0:
                                     if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                        leastPrivilegeRating = 'failed_high'
+                                        leastPrivilegeRating = 'failedHigh'
                                         # Means that an initial failure will not be overwritten by a lower finding later
                                         next
                                     elif type(statement['Resource']) == list: 
-                                        leastPrivilegeRating = 'failed_low'
+                                        leastPrivilegeRating = 'failedLow'
 
                             # Single action in a statement
                             elif type(statement['Action']) == str:
                                 if ":*" in statement['Action'] or statement['Action'] == '*':
                                     if type(statement['Resource']) == str and statement['Resource'] == '*':
-                                        leastPrivilegeRating = 'failed_high'
+                                        leastPrivilegeRating = 'failedHigh'
                                         # Means that an initial failure will not be overwritten by a lower finding later
                                         next
                                     elif type(statement['Resource']) == list: 
-                                        leastPrivilegeRating = 'failed_low'
+                                        leastPrivilegeRating = 'failedLow'
                 
                 if leastPrivilegeRating == 'passing':
                     finding = {
@@ -2015,7 +2005,7 @@ def iam_role_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                         "RecordState": "ARCHIVED",
                     }
                     yield finding
-                elif leastPrivilegeRating == 'failed_low':
+                elif leastPrivilegeRating == 'failedLow':
                     finding = {
                         "SchemaVersion": "2018-10-08",
                         "Id": f"{roleArn}/role_policy_least_priv",
@@ -2076,7 +2066,7 @@ def iam_role_policy_least_priv_check(cache: dict, awsAccountId: str, awsRegion: 
                         "RecordState": "ACTIVE",
                     }
                     yield finding
-                elif leastPrivilegeRating == 'failed_high':
+                elif leastPrivilegeRating == 'failedHigh':
                     finding = {
                         "SchemaVersion": "2018-10-08",
                         "Id": f"{roleArn}/role_policy_least_priv",

--- a/eeauditor/auditors/aws/AWS_IAM_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_IAM_Auditor.py
@@ -430,6 +430,7 @@ def user_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition:
                     "RecordState": "ACTIVE"
                 }
                 yield finding
+            # this is passing check
             else:
                 finding = {
                     "SchemaVersion": "2018-10-08",
@@ -576,150 +577,145 @@ def user_inline_policy_check(cache: dict, awsAccountId: str, awsRegion: str, aws
     for users in list_users(cache)["Users"]:
         userName = str(users["UserName"])
         userArn = str(users["Arn"])
-        try:
-            response = iam.list_user_policies(UserName=userName)
-            if str(response["PolicyNames"]) != "[]":
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": userArn + "/iam-user-attach-inline-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": userArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[IAM.4] IAM users should not have attached in-line policies",
-                    "Description": "IAM user "
-                    + userName
-                    + " has an in-line policy attached. It is recommended that IAM policies be applied directly to groups and roles but not users. Refer to the remediation section if this behavior is not intended.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamUser",
-                            "Id": userArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "AwsIamUser": {
-                                    "UserName": userName
-                                }
+        # use a list comprehension to check if there are any inline policies
+        # this is a failing check
+        if iam.list_user_policies(UserName=userName)["PolicyNames"]:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{userArn}/iam-user-attach-inline-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": userArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "LOW"},
+                "Confidence": 99,
+                "Title": "[IAM.4] IAM users should not have attached in-line policies",
+                "Description": f"IAM user {userName} has an in-line policy attached. It is recommended that IAM policies be applied directly to groups and roles but not users. Refer to the remediation section if this behavior is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamUser",
+                        "Id": userArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsIamUser": {
+                                "UserName": userName
                             }
                         }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.AC-1",
-                            "NIST SP 800-53 AC-1",
-                            "NIST SP 800-53 AC-2",
-                            "NIST SP 800-53 IA-1",
-                            "NIST SP 800-53 IA-2",
-                            "NIST SP 800-53 IA-3",
-                            "NIST SP 800-53 IA-4",
-                            "NIST SP 800-53 IA-5",
-                            "NIST SP 800-53 IA-6",
-                            "NIST SP 800-53 IA-7",
-                            "NIST SP 800-53 IA-8",
-                            "NIST SP 800-53 IA-9",
-                            "NIST SP 800-53 IA-10",
-                            "NIST SP 800-53 IA-11",
-                            "AICPA TSC CC6.1",
-                            "AICPA TSC CC6.2",
-                            "ISO 27001:2013 A.9.2.1",
-                            "ISO 27001:2013 A.9.2.2",
-                            "ISO 27001:2013 A.9.2.3",
-                            "ISO 27001:2013 A.9.2.4",
-                            "ISO 27001:2013 A.9.2.6",
-                            "ISO 27001:2013 A.9.3.1",
-                            "ISO 27001:2013 A.9.4.2",
-                            "ISO 27001:2013 A.9.4.3"
-                        ]
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE"
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": userArn + "/iam-user-attach-inline-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": userArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "INFORMATIONAL"},
-                    "Confidence": 99,
-                    "Title": "[IAM.4] IAM users should not have attached in-line policies",
-                    "Description": "IAM user "
-                    + userName
-                    + " does not have an in-line policy attached.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamUser",
-                            "Id": userArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "AwsIamUser": {
-                                    "UserName": userName
-                                }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-1",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-2",
+                        "NIST SP 800-53 IA-1",
+                        "NIST SP 800-53 IA-2",
+                        "NIST SP 800-53 IA-3",
+                        "NIST SP 800-53 IA-4",
+                        "NIST SP 800-53 IA-5",
+                        "NIST SP 800-53 IA-6",
+                        "NIST SP 800-53 IA-7",
+                        "NIST SP 800-53 IA-8",
+                        "NIST SP 800-53 IA-9",
+                        "NIST SP 800-53 IA-10",
+                        "NIST SP 800-53 IA-11",
+                        "AICPA TSC CC6.1",
+                        "AICPA TSC CC6.2",
+                        "ISO 27001:2013 A.9.2.1",
+                        "ISO 27001:2013 A.9.2.2",
+                        "ISO 27001:2013 A.9.2.3",
+                        "ISO 27001:2013 A.9.2.4",
+                        "ISO 27001:2013 A.9.2.6",
+                        "ISO 27001:2013 A.9.3.1",
+                        "ISO 27001:2013 A.9.4.2",
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        # this is a passing check
+        else:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{userArn}/iam-user-attach-inline-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": userArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[IAM.4] IAM users should not have attached in-line policies",
+                "Description": "IAM user {userName} does not have an in-line policy attached.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamUser",
+                        "Id": userArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsIamUser": {
+                                "UserName": userName
                             }
                         }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.AC-1",
-                            "NIST SP 800-53 AC-1",
-                            "NIST SP 800-53 AC-2",
-                            "NIST SP 800-53 IA-1",
-                            "NIST SP 800-53 IA-2",
-                            "NIST SP 800-53 IA-3",
-                            "NIST SP 800-53 IA-4",
-                            "NIST SP 800-53 IA-5",
-                            "NIST SP 800-53 IA-6",
-                            "NIST SP 800-53 IA-7",
-                            "NIST SP 800-53 IA-8",
-                            "NIST SP 800-53 IA-9",
-                            "NIST SP 800-53 IA-10",
-                            "NIST SP 800-53 IA-11",
-                            "AICPA TSC CC6.1",
-                            "AICPA TSC CC6.2",
-                            "ISO 27001:2013 A.9.2.1",
-                            "ISO 27001:2013 A.9.2.2",
-                            "ISO 27001:2013 A.9.2.3",
-                            "ISO 27001:2013 A.9.2.4",
-                            "ISO 27001:2013 A.9.2.6",
-                            "ISO 27001:2013 A.9.3.1",
-                            "ISO 27001:2013 A.9.4.2",
-                            "ISO 27001:2013 A.9.4.3"
-                        ]
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED"
-                }
-                yield finding
-        except Exception as e:
-            print(e)
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-1",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-2",
+                        "NIST SP 800-53 IA-1",
+                        "NIST SP 800-53 IA-2",
+                        "NIST SP 800-53 IA-3",
+                        "NIST SP 800-53 IA-4",
+                        "NIST SP 800-53 IA-5",
+                        "NIST SP 800-53 IA-6",
+                        "NIST SP 800-53 IA-7",
+                        "NIST SP 800-53 IA-8",
+                        "NIST SP 800-53 IA-9",
+                        "NIST SP 800-53 IA-10",
+                        "NIST SP 800-53 IA-11",
+                        "AICPA TSC CC6.1",
+                        "AICPA TSC CC6.2",
+                        "ISO 27001:2013 A.9.2.1",
+                        "ISO 27001:2013 A.9.2.2",
+                        "ISO 27001:2013 A.9.2.3",
+                        "ISO 27001:2013 A.9.2.4",
+                        "ISO 27001:2013 A.9.2.6",
+                        "ISO 27001:2013 A.9.3.1",
+                        "ISO 27001:2013 A.9.4.2",
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
 
 @registry.register_check("iam")
 def user_direct_attached_policy_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
@@ -729,150 +725,145 @@ def user_direct_attached_policy_check(cache: dict, awsAccountId: str, awsRegion:
     for users in list_users(cache)["Users"]:
         userName = str(users["UserName"])
         userArn = str(users["Arn"])
-        try:
-            response = iam.list_attached_user_policies(UserName=userName)
-            if str(response["AttachedPolicies"]) != "[]":
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": userArn + "/iam-user-attach-managed-policy-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": userArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "LOW"},
-                    "Confidence": 99,
-                    "Title": "[IAM.5] IAM users should not have attached managed policies",
-                    "Description": "IAM user "
-                    + userName
-                    + " has a managed policy attached. It is recommended that IAM policies be applied directly to groups and roles but not users. Refer to the remediation section if this behavior is not intended.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamUser",
-                            "Id": userArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "AwsIamUser": {
-                                    "UserName": userName
-                                }
+        # use a list comprehension to check if there are any attached managed policies
+        # this is a failing check
+        if iam.list_attached_user_policies(UserName=userName)["AttachedPolicies"]:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{userArn}/iam-user-attach-managed-policy-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": userArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "LOW"},
+                "Confidence": 99,
+                "Title": "[IAM.5] IAM users should not have attached managed policies",
+                "Description": f"IAM user {userName} has a managed policy attached. It is recommended that IAM policies be applied directly to groups and roles but not users. Refer to the remediation section if this behavior is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamUser",
+                        "Id": userArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsIamUser": {
+                                "UserName": userName
                             }
                         }
-                    ],
-                    "Compliance": {
-                        "Status": "FAILED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.AC-1",
-                            "NIST SP 800-53 AC-1",
-                            "NIST SP 800-53 AC-2",
-                            "NIST SP 800-53 IA-1",
-                            "NIST SP 800-53 IA-2",
-                            "NIST SP 800-53 IA-3",
-                            "NIST SP 800-53 IA-4",
-                            "NIST SP 800-53 IA-5",
-                            "NIST SP 800-53 IA-6",
-                            "NIST SP 800-53 IA-7",
-                            "NIST SP 800-53 IA-8",
-                            "NIST SP 800-53 IA-9",
-                            "NIST SP 800-53 IA-10",
-                            "NIST SP 800-53 IA-11",
-                            "AICPA TSC CC6.1",
-                            "AICPA TSC CC6.2",
-                            "ISO 27001:2013 A.9.2.1",
-                            "ISO 27001:2013 A.9.2.2",
-                            "ISO 27001:2013 A.9.2.3",
-                            "ISO 27001:2013 A.9.2.4",
-                            "ISO 27001:2013 A.9.2.6",
-                            "ISO 27001:2013 A.9.3.1",
-                            "ISO 27001:2013 A.9.4.2",
-                            "ISO 27001:2013 A.9.4.3"
-                        ]
-                    },
-                    "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE"
-                }
-                yield finding
-            else:
-                finding = {
-                    "SchemaVersion": "2018-10-08",
-                    "Id": userArn + "/iam-user-attach-managed-policy-check",
-                    "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": userArn,
-                    "AwsAccountId": awsAccountId,
-                    "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-                    "FirstObservedAt": iso8601Time,
-                    "CreatedAt": iso8601Time,
-                    "UpdatedAt": iso8601Time,
-                    "Severity": {"Label": "INFORMATIONAL"},
-                    "Confidence": 99,
-                    "Title": "[IAM.5] IAM users should not have attached managed policies",
-                    "Description": "IAM user "
-                    + userName
-                    + " does not have a managed policy attached.",
-                    "Remediation": {
-                        "Recommendation": {
-                            "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
-                            "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html",
-                        }
-                    },
-                    "ProductFields": {"Product Name": "ElectricEye"},
-                    "Resources": [
-                        {
-                            "Type": "AwsIamUser",
-                            "Id": userArn,
-                            "Partition": awsPartition,
-                            "Region": awsRegion,
-                            "Details": {
-                                "AwsIamUser": {
-                                    "UserName": userName
-                                }
+                    }
+                ],
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-1",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-2",
+                        "NIST SP 800-53 IA-1",
+                        "NIST SP 800-53 IA-2",
+                        "NIST SP 800-53 IA-3",
+                        "NIST SP 800-53 IA-4",
+                        "NIST SP 800-53 IA-5",
+                        "NIST SP 800-53 IA-6",
+                        "NIST SP 800-53 IA-7",
+                        "NIST SP 800-53 IA-8",
+                        "NIST SP 800-53 IA-9",
+                        "NIST SP 800-53 IA-10",
+                        "NIST SP 800-53 IA-11",
+                        "AICPA TSC CC6.1",
+                        "AICPA TSC CC6.2",
+                        "ISO 27001:2013 A.9.2.1",
+                        "ISO 27001:2013 A.9.2.2",
+                        "ISO 27001:2013 A.9.2.3",
+                        "ISO 27001:2013 A.9.2.4",
+                        "ISO 27001:2013 A.9.2.6",
+                        "ISO 27001:2013 A.9.3.1",
+                        "ISO 27001:2013 A.9.4.2",
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE"
+            }
+            yield finding
+        # this is a passing check
+        else:
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": f"{userArn}/iam-user-attach-managed-policy-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": userArn,
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "INFORMATIONAL"},
+                "Confidence": 99,
+                "Title": "[IAM.5] IAM users should not have attached managed policies",
+                "Description": f"IAM user {userName} does not have a managed policy attached.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on user attached policies refer to the Managed Policies and Inline Policies section of the AWS IAM User Guide",
+                        "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html"
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsIamUser",
+                        "Id": userArn,
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                        "Details": {
+                            "AwsIamUser": {
+                                "UserName": userName
                             }
                         }
-                    ],
-                    "Compliance": {
-                        "Status": "PASSED",
-                        "RelatedRequirements": [
-                            "NIST CSF PR.AC-1",
-                            "NIST SP 800-53 AC-1",
-                            "NIST SP 800-53 AC-2",
-                            "NIST SP 800-53 IA-1",
-                            "NIST SP 800-53 IA-2",
-                            "NIST SP 800-53 IA-3",
-                            "NIST SP 800-53 IA-4",
-                            "NIST SP 800-53 IA-5",
-                            "NIST SP 800-53 IA-6",
-                            "NIST SP 800-53 IA-7",
-                            "NIST SP 800-53 IA-8",
-                            "NIST SP 800-53 IA-9",
-                            "NIST SP 800-53 IA-10",
-                            "NIST SP 800-53 IA-11",
-                            "AICPA TSC CC6.1",
-                            "AICPA TSC CC6.2",
-                            "ISO 27001:2013 A.9.2.1",
-                            "ISO 27001:2013 A.9.2.2",
-                            "ISO 27001:2013 A.9.2.3",
-                            "ISO 27001:2013 A.9.2.4",
-                            "ISO 27001:2013 A.9.2.6",
-                            "ISO 27001:2013 A.9.3.1",
-                            "ISO 27001:2013 A.9.4.2",
-                            "ISO 27001:2013 A.9.4.3"
-                        ]
-                    },
-                    "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED"
-                }
-                yield finding
-        except Exception as e:
-            print(e)
+                    }
+                ],
+                "Compliance": {
+                    "Status": "PASSED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-1",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-2",
+                        "NIST SP 800-53 IA-1",
+                        "NIST SP 800-53 IA-2",
+                        "NIST SP 800-53 IA-3",
+                        "NIST SP 800-53 IA-4",
+                        "NIST SP 800-53 IA-5",
+                        "NIST SP 800-53 IA-6",
+                        "NIST SP 800-53 IA-7",
+                        "NIST SP 800-53 IA-8",
+                        "NIST SP 800-53 IA-9",
+                        "NIST SP 800-53 IA-10",
+                        "NIST SP 800-53 IA-11",
+                        "AICPA TSC CC6.1",
+                        "AICPA TSC CC6.2",
+                        "ISO 27001:2013 A.9.2.1",
+                        "ISO 27001:2013 A.9.2.2",
+                        "ISO 27001:2013 A.9.2.3",
+                        "ISO 27001:2013 A.9.2.4",
+                        "ISO 27001:2013 A.9.2.6",
+                        "ISO 27001:2013 A.9.3.1",
+                        "ISO 27001:2013 A.9.4.2",
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
+                },
+                "Workflow": {"Status": "RESOLVED"},
+                "RecordState": "ARCHIVED"
+            }
+            yield finding
 
 @registry.register_check("iam")
 def cis_aws_foundation_benchmark_pw_policy_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
@@ -1029,72 +1020,74 @@ def cis_aws_foundation_benchmark_pw_policy_check(cache: dict, awsAccountId: str,
                 "RecordState": "ACTIVE"
             }
             yield finding
-    except Exception:
-        # create a HIGH alert if there is not one at all
-        finding = {
-            "SchemaVersion": "2018-10-08",
-            "Id": awsAccountId + "/cis-aws-foundations-benchmark-pw-policy-check",
-            "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-            "GeneratorId": awsAccountId + "iam-password-policy",
-            "AwsAccountId": awsAccountId,
-            "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
-            "FirstObservedAt": iso8601Time,
-            "CreatedAt": iso8601Time,
-            "UpdatedAt": iso8601Time,
-            "Severity": {"Label": "HIGH"},
-            "Confidence": 99,
-            "Title": "[IAM.6] The IAM password policy should meet or exceed the AWS CIS Foundations Benchmark standard",
-            "Description": "The IAM password policy for account "
-            + awsAccountId
-            + " was not found! Refer to the remediation instructions if this configuration is not intended.",
-            "Remediation": {
-                "Recommendation": {
-                    "Text": "For information on the CIS AWS Foundations Benchmark standard for the password policy refer to the linked Standard",
-                    "Url": "https://d1.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf",
-                }
-            },
-            "ProductFields": {"Product Name": "ElectricEye"},
-            "Resources": [
-                {
-                    "Type": "AwsAccount",
-                    "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
-                    "Partition": awsPartition,
-                    "Region": awsRegion,
-                }
-            ],
-            "Compliance": {
-                "Status": "FAILED",
-                "RelatedRequirements": [
-                    "NIST CSF PR.AC-1",
-                    "NIST SP 800-53 AC-1",
-                    "NIST SP 800-53 AC-2",
-                    "NIST SP 800-53 IA-1",
-                    "NIST SP 800-53 IA-2",
-                    "NIST SP 800-53 IA-3",
-                    "NIST SP 800-53 IA-4",
-                    "NIST SP 800-53 IA-5",
-                    "NIST SP 800-53 IA-6",
-                    "NIST SP 800-53 IA-7",
-                    "NIST SP 800-53 IA-8",
-                    "NIST SP 800-53 IA-9",
-                    "NIST SP 800-53 IA-10",
-                    "NIST SP 800-53 IA-11",
-                    "AICPA TSC CC6.1",
-                    "AICPA TSC CC6.2",
-                    "ISO 27001:2013 A.9.2.1",
-                    "ISO 27001:2013 A.9.2.2",
-                    "ISO 27001:2013 A.9.2.3",
-                    "ISO 27001:2013 A.9.2.4",
-                    "ISO 27001:2013 A.9.2.6",
-                    "ISO 27001:2013 A.9.3.1",
-                    "ISO 27001:2013 A.9.4.2",
-                    "ISO 27001:2013 A.9.4.3",
+    # this is a failing check
+    except botocore.exceptions.ClientError as error:
+        # Handle "NoSuchEntity" exception which means the PW policy does not exist
+        if error.response['Error']['Code'] == 'NoSuchEntity':
+            finding = {
+                "SchemaVersion": "2018-10-08",
+                "Id": awsAccountId + "/cis-aws-foundations-benchmark-pw-policy-check",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
+                "GeneratorId": awsAccountId + "iam-password-policy",
+                "AwsAccountId": awsAccountId,
+                "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
+                "FirstObservedAt": iso8601Time,
+                "CreatedAt": iso8601Time,
+                "UpdatedAt": iso8601Time,
+                "Severity": {"Label": "HIGH"},
+                "Confidence": 99,
+                "Title": "[IAM.6] The IAM password policy should meet or exceed the AWS CIS Foundations Benchmark standard",
+                "Description": "The IAM password policy for account "
+                + awsAccountId
+                + " was not found! Refer to the remediation instructions if this configuration is not intended.",
+                "Remediation": {
+                    "Recommendation": {
+                        "Text": "For information on the CIS AWS Foundations Benchmark standard for the password policy refer to the linked Standard",
+                        "Url": "https://d1.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf",
+                    }
+                },
+                "ProductFields": {"Product Name": "ElectricEye"},
+                "Resources": [
+                    {
+                        "Type": "AwsAccount",
+                        "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
+                        "Partition": awsPartition,
+                        "Region": awsRegion,
+                    }
                 ],
-            },
-            "Workflow": {"Status": "NEW"},
-            "RecordState": "ACTIVE",
-        }
-        yield finding
+                "Compliance": {
+                    "Status": "FAILED",
+                    "RelatedRequirements": [
+                        "NIST CSF PR.AC-1",
+                        "NIST SP 800-53 AC-1",
+                        "NIST SP 800-53 AC-2",
+                        "NIST SP 800-53 IA-1",
+                        "NIST SP 800-53 IA-2",
+                        "NIST SP 800-53 IA-3",
+                        "NIST SP 800-53 IA-4",
+                        "NIST SP 800-53 IA-5",
+                        "NIST SP 800-53 IA-6",
+                        "NIST SP 800-53 IA-7",
+                        "NIST SP 800-53 IA-8",
+                        "NIST SP 800-53 IA-9",
+                        "NIST SP 800-53 IA-10",
+                        "NIST SP 800-53 IA-11",
+                        "AICPA TSC CC6.1",
+                        "AICPA TSC CC6.2",
+                        "ISO 27001:2013 A.9.2.1",
+                        "ISO 27001:2013 A.9.2.2",
+                        "ISO 27001:2013 A.9.2.3",
+                        "ISO 27001:2013 A.9.2.4",
+                        "ISO 27001:2013 A.9.2.6",
+                        "ISO 27001:2013 A.9.3.1",
+                        "ISO 27001:2013 A.9.4.2",
+                        "ISO 27001:2013 A.9.4.3",
+                    ],
+                },
+                "Workflow": {"Status": "NEW"},
+                "RecordState": "ACTIVE",
+            }
+            yield finding
 
 @registry.register_check("iam")
 def server_certs_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:

--- a/eeauditor/auditors/aws/AWS_IAM_Auditor.py
+++ b/eeauditor/auditors/aws/AWS_IAM_Auditor.py
@@ -59,7 +59,7 @@ def iam_access_key_age_check(cache: dict, awsAccountId: str, awsRegion: str, aws
                     # this is a passing check
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": keyUserName + keyId + "/iam-access-key-age-check",
+                        "Id": f"{keyUserName}{keyId}/iam-access-key-age-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": userArn + keyId,
                         "AwsAccountId": awsAccountId,
@@ -72,15 +72,11 @@ def iam_access_key_age_check(cache: dict, awsAccountId: str, awsRegion: str, aws
                         "Severity": {"Label": "INFORMATIONAL"},
                         "Confidence": 99,
                         "Title": "[IAM.1] IAM Access Keys should be rotated every 90 days",
-                        "Description": "IAM access key "
-                        + keyId
-                        + " for user "
-                        + keyUserName
-                        + " is not over 90 days old.",
+                        "Description": f"IAM access key {keyId} for user {keyUserName} is not over 90 days old.",
                         "Remediation": {
                             "Recommendation": {
                                 "Text": "For information on IAM access key rotation refer to the Rotating Access Keys section of the AWS IAM User Guide",
-                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey",
+                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey"
                             }
                         },
                         "ProductFields": {"Product Name": "ElectricEye"},
@@ -94,9 +90,9 @@ def iam_access_key_age_check(cache: dict, awsAccountId: str, awsRegion: str, aws
                                     "AwsIamAccessKey": {
                                         "PrincipalId": keyId,
                                         "PrincipalName": keyUserName,
-                                        "Status": keyStatus,
+                                        "Status": keyStatus
                                     }
-                                },
+                                }
                             }
                         ],
                         "Compliance": {
@@ -126,37 +122,34 @@ def iam_access_key_age_check(cache: dict, awsAccountId: str, awsRegion: str, aws
                                 "ISO 27001:2013 A.9.3.1",
                                 "ISO 27001:2013 A.9.4.2",
                                 "ISO 27001:2013 A.9.4.3",
-                            ],
+                                "MITRE ATT&CK T1589",
+                                "MITRE ATT&CK T1586"
+                            ]
                         },
                         "Workflow": {"Status": "RESOLVED"},
-                        "RecordState": "ARCHIVED",
+                        "RecordState": "ARCHIVED"
                     }
                     yield finding
                 else:
+                    # this is a failing check
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": keyUserName + keyId + "/iam-access-key-age-check",
+                        "Id": f"{keyUserName}{keyId}/iam-access-key-age-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": userArn + keyId,
                         "AwsAccountId": awsAccountId,
-                        "Types": [
-                            "Software and Configuration Checks/AWS Security Best Practices"
-                        ],
+                        "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                         "FirstObservedAt": iso8601Time,
                         "CreatedAt": iso8601Time,
                         "UpdatedAt": iso8601Time,
                         "Severity": {"Label": "MEDIUM"},
                         "Confidence": 99,
                         "Title": "[IAM.1] IAM Access Keys should be rotated every 90 days",
-                        "Description": "IAM access key "
-                        + keyId
-                        + " for user "
-                        + keyUserName
-                        + " is over 90 days old. As a security best practice, AWS recommends that you regularly rotate (change) IAM user access keys. If your administrator granted you the necessary permissions, you can rotate your own access keys. Refer to the remediation section if this behavior is not intended.",
+                        "Description": f"IAM access key {keyId} for user {keyUserName} is over 90 days old. As a security best practice, AWS recommends that you regularly rotate (change) IAM user access keys. If your administrator granted you the necessary permissions, you can rotate your own access keys. Refer to the remediation section if this behavior is not intended.",
                         "Remediation": {
                             "Recommendation": {
                                 "Text": "For information on IAM access key rotation refer to the Rotating Access Keys section of the AWS IAM User Guide",
-                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey",
+                                "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey"
                             }
                         },
                         "ProductFields": {"Product Name": "ElectricEye"},
@@ -170,9 +163,9 @@ def iam_access_key_age_check(cache: dict, awsAccountId: str, awsRegion: str, aws
                                     "AwsIamAccessKey": {
                                         "PrincipalId": keyId,
                                         "PrincipalName": keyUserName,
-                                        "Status": keyStatus,
+                                        "Status": keyStatus
                                     }
-                                },
+                                }
                             }
                         ],
                         "Compliance": {
@@ -202,12 +195,15 @@ def iam_access_key_age_check(cache: dict, awsAccountId: str, awsRegion: str, aws
                                 "ISO 27001:2013 A.9.3.1",
                                 "ISO 27001:2013 A.9.4.2",
                                 "ISO 27001:2013 A.9.4.3",
-                            ],
+                                "MITRE ATT&CK T1589",
+                                "MITRE ATT&CK T1586"
+                            ]
                         },
                         "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
+                        "RecordState": "ACTIVE"
                     }
                     yield finding
+            # skip Inactive keys
             else:
                 continue
 

--- a/eeauditor/auditors/aws/Amazon_APIGW_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_APIGW_Auditor.py
@@ -738,7 +738,7 @@ def api_gateway_stage_waf_check_check(cache: dict, awsAccountId: str, awsRegion:
                     "AwsAccountId": awsAccountId,
                     "Types": [
                         "Software and Configuration Checks/AWS Security Best Practices",
-                        "Effects/Data Exposure",
+                        "Effects/Data Exposure"
                     ],
                     "FirstObservedAt": iso8601Time,
                     "CreatedAt": iso8601Time,
@@ -770,7 +770,7 @@ def api_gateway_stage_waf_check_check(cache: dict, awsAccountId: str, awsRegion:
                                     "StageName": apiStageName,
                                     "WebAclArn": wafCheck
                                 }
-                            },
+                            }
                         }
                     ],
                     "Compliance": {
@@ -785,10 +785,13 @@ def api_gateway_stage_waf_check_check(cache: dict, awsAccountId: str, awsRegion:
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1190"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             # this is a failing check
@@ -801,7 +804,7 @@ def api_gateway_stage_waf_check_check(cache: dict, awsAccountId: str, awsRegion:
                     "AwsAccountId": awsAccountId,
                     "Types": [
                         "Software and Configuration Checks/AWS Security Best Practices",
-                        "Effects/Data Exposure",
+                        "Effects/Data Exposure"
                     ],
                     "FirstObservedAt": iso8601Time,
                     "CreatedAt": iso8601Time,
@@ -830,9 +833,9 @@ def api_gateway_stage_waf_check_check(cache: dict, awsAccountId: str, awsRegion:
                             "Details": {
                                 "AwsApiGatewayStage": {
                                     "DeploymentId": apiStageDeploymentId,
-                                    "StageName": apiStageName,
+                                    "StageName": apiStageName
                                 }
-                            },
+                            }
                         }
                     ],
                     "Compliance": {
@@ -847,10 +850,13 @@ def api_gateway_stage_waf_check_check(cache: dict, awsAccountId: str, awsRegion:
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1190"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
 

--- a/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CloudFront_Auditor.py
@@ -802,7 +802,10 @@ def cloudfront_waf_enabled_check(cache: dict, awsAccountId: str, awsRegion: str,
                         "AICPA TSC CC7.2",
                         "ISO 27001:2013 A.12.4.1",
                         "ISO 27001:2013 A.16.1.1",
-                        "ISO 27001:2013 A.16.1.4"
+                        "ISO 27001:2013 A.16.1.4",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1190"
                     ]
                 },
                 "Workflow": {"Status": "NEW"},
@@ -857,7 +860,10 @@ def cloudfront_waf_enabled_check(cache: dict, awsAccountId: str, awsRegion: str,
                         "AICPA TSC CC7.2",
                         "ISO 27001:2013 A.12.4.1",
                         "ISO 27001:2013 A.16.1.1",
-                        "ISO 27001:2013 A.16.1.4"
+                        "ISO 27001:2013 A.16.1.4",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1190"
                     ]
                 },
                 "Workflow": {"Status": "RESOLVED"},

--- a/eeauditor/auditors/aws/Amazon_CognitoIdP_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CognitoIdP_Auditor.py
@@ -37,13 +37,12 @@ def list_user_pools(cache):
     )
     return cache["list_user_pools"]
 
-
 @registry.register_check("sns")
 def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Cognito-IdP.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards"""
-    response = list_user_pools(cache)
-    myCognitoUserPools = response["UserPools"]
-    for userpools in myCognitoUserPools:
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for userpools in list_user_pools(cache)["UserPools"]:
         userPoolId = str(userpools["Id"])
         response = cognitoidp.describe_user_pool(UserPoolId=userPoolId)
         userPoolArn = str(response["UserPool"]["Arn"])
@@ -54,8 +53,6 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
         lowercaseCheck = str(cognitoPwPolicy["RequireLowercase"])
         numberCheck = str(cognitoPwPolicy["RequireNumbers"])
         symbolCheck = str(cognitoPwPolicy["RequireSymbols"])
-        # ISO Time
-        iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
         if (
             minLengthCheck >= 14
             and uppercaseCheck == "True"
@@ -64,7 +61,6 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
             and symbolCheck == "True"
         ):
             # this is a passing check
-            # create Sec Hub finding
             finding = {
                 "SchemaVersion": "2018-10-08",
                 "Id": userPoolArn + "/cognito-user-pool-password-policy",
@@ -78,13 +74,11 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
                 "Title": "[Cognito-IdP.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards",
-                "Description": "Cognito user pool "
-                + userPoolArn
-                + " meets the password guidelines.",
+                "Description": f"Cognito user pool {userPoolArn} meets the password guidelines.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "To ensure you Cognito user pools have a password policy that meets or exceed AWS CIS Foundations Benchmark standards refer to the Adding User Pool Password Requirements section of the Amazon Cognito Developer Guide",
-                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html",
+                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -94,7 +88,7 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                         "Id": userPoolArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"UserPoolId": userPoolId}},
+                        "Details": {"Other": {"UserPoolId": userPoolId}}
                     }
                 ],
                 "Compliance": {
@@ -123,15 +117,15 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                         "ISO 27001:2013 A.9.2.6",
                         "ISO 27001:2013 A.9.3.1",
                         "ISO 27001:2013 A.9.4.2",
-                        "ISO 27001:2013 A.9.4.3",
-                    ],
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
-                "RecordState": "ARCHIVED",
+                "RecordState": "ARCHIVED"
             }
             yield finding
         else:
-            # create Sec Hub finding
+            # this is a failing check
             finding = {
                 "SchemaVersion": "2018-10-08",
                 "Id": userPoolArn + "/cognito-user-pool-password-policy",
@@ -145,13 +139,11 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                 "Severity": {"Label": "MEDIUM"},
                 "Confidence": 99,
                 "Title": "[Cognito-IdP.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards",
-                "Description": "Cognito user pool "
-                + userPoolArn
-                + " does not meet the password guidelines. Password policies, in part, enforce password complexity requirements, setting a password complexity policy increases account resiliency against brute force login attempts. Refer to the remediation instructions to remediate this behavior",
+                "Description": f"Cognito user pool {userPoolArn} does not meet the password guidelines. Password policies, in part, enforce password complexity requirements, setting a password complexity policy increases account resiliency against brute force login attempts. Refer to the remediation instructions to remediate this behavior.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "To ensure you Cognito user pools have a password policy that meets or exceed AWS CIS Foundations Benchmark standards refer to the Adding User Pool Password Requirements section of the Amazon Cognito Developer Guide",
-                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html",
+                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -161,7 +153,7 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                         "Id": userPoolArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"UserPoolId": userPoolId}},
+                        "Details": {"Other": {"UserPoolId": userPoolId}}
                     }
                 ],
                 "Compliance": {
@@ -190,11 +182,11 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                         "ISO 27001:2013 A.9.2.6",
                         "ISO 27001:2013 A.9.3.1",
                         "ISO 27001:2013 A.9.4.2",
-                        "ISO 27001:2013 A.9.4.3",
-                    ],
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
+                "RecordState": "ACTIVE"
             }
             yield finding
 
@@ -202,22 +194,20 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
 @registry.register_check("sns")
 def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Cognito-IdP.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours"""
-    response = list_user_pools(cache)
-    myCognitoUserPools = response["UserPools"]
-    for userpools in myCognitoUserPools:
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for userpools in list_user_pools(cache)["UserPools"]:
         userPoolId = str(userpools["Id"])
         response = cognitoidp.describe_user_pool(UserPoolId=userPoolId)
         userPoolArn = str(response["UserPool"]["Arn"])
         userPoolId = str(response["UserPool"]["Id"])
         cognitoPwPolicy = response["UserPool"]["Policies"]["PasswordPolicy"]
         tempPwValidityCheck = int(cognitoPwPolicy["TemporaryPasswordValidityDays"])
-        # ISO Time
-        iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
         if tempPwValidityCheck > 1:
-            # create Sec Hub finding
+            # this is a failing check
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userPoolArn + "/cognito-user-pool-temp-password-life",
+                "Id": f"{userPoolArn}/cognito-user-pool-temp-password-life",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userPoolId,
                 "AwsAccountId": awsAccountId,
@@ -228,13 +218,11 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                 "Severity": {"Label": "MEDIUM"},
                 "Confidence": 99,
                 "Title": "[Cognito-IdP.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours",
-                "Description": "Cognito user pool "
-                + userPoolArn
-                + " allows temporary passwords to stay valid beyond 24 hours. Password policies, in part, enforce password complexity requirements, setting a password complexity policy increases account resiliency against brute force login attempts. Refer to the remediation instructions if this configuration is not intended",
+                "Description": f"Cognito user pool {userPoolArn} allows temporary passwords to stay valid beyond 24 hours. Password policies, in part, enforce password complexity requirements, setting a password complexity policy increases account resiliency against brute force login attempts. Refer to the remediation instructions if this configuration is not intended.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "To modify your Cognito user pool temporary password policy refer to the Authentication Flow for Users Created by Administrators or Developers section of the Amazon Cognito Developer Guide",
-                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html",
+                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -244,7 +232,7 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                         "Id": userPoolArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"UserPoolId": userPoolId}},
+                        "Details": {"Other": {"UserPoolId": userPoolId}}
                     }
                 ],
                 "Compliance": {
@@ -274,16 +262,19 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                         "ISO 27001:2013 A.9.3.1",
                         "ISO 27001:2013 A.9.4.2",
                         "ISO 27001:2013 A.9.4.3",
-                    ],
+                        "MITRE ATT&CK T1589",
+                        "MITRE ATT&CK T1586"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
+                "RecordState": "ACTIVE"
             }
             yield finding
+        # this is a passing check
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userPoolArn + "/cognito-user-pool-temp-password-life",
+                "Id": f"{userPoolArn}/cognito-user-pool-temp-password-life",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userPoolId,
                 "AwsAccountId": awsAccountId,
@@ -294,13 +285,11 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
                 "Title": "[Cognito-IdP.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours",
-                "Description": "Cognito user pool "
-                + userPoolArn
-                + " does not allow temporary passwords to stay valid beyond 24 hours.",
+                "Description": f"Cognito user pool {userPoolArn} does not allow temporary passwords to stay valid beyond 24 hours.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "To modify your Cognito user pool temporary password policy refer to the Authentication Flow for Users Created by Administrators or Developers section of the Amazon Cognito Developer Guide",
-                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html",
+                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -310,7 +299,7 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                         "Id": userPoolArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"UserPoolId": userPoolId}},
+                        "Details": {"Other": {"UserPoolId": userPoolId}}
                     }
                 ],
                 "Compliance": {
@@ -340,31 +329,32 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                         "ISO 27001:2013 A.9.3.1",
                         "ISO 27001:2013 A.9.4.2",
                         "ISO 27001:2013 A.9.4.3",
-                    ],
+                        "MITRE ATT&CK T1589",
+                        "MITRE ATT&CK T1586"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
-                "RecordState": "ARCHIVED",
+                "RecordState": "ARCHIVED"
             }
             yield finding
-
 
 @registry.register_check("sns")
 def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[Cognito-IdP.3] Cognito user pools should enforce multi factor authentication (MFA)"""
-    response = list_user_pools(cache)
-    myCognitoUserPools = response["UserPools"]
-    for userpools in myCognitoUserPools:
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for userpools in list_user_pools(cache)["UserPools"]:
         userPoolId = str(userpools["Id"])
-        response = cognitoidp.describe_user_pool(UserPoolId=userPoolId)
-        userPoolArn = str(response["UserPool"]["Arn"])
-        userPoolId = str(response["UserPool"]["Id"])
-        mfaCheck = str(response["UserPool"]["MfaConfiguration"])
-        # ISO Time
-        iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+        # Get specific user pool info
+        r = cognitoidp.describe_user_pool(UserPoolId=userPoolId)
+        userPoolArn = str(r["UserPool"]["Arn"])
+        userPoolId = str(r["UserPool"]["Id"])
+        mfaCheck = str(r["UserPool"]["MfaConfiguration"])
         if mfaCheck != "ON":
+            # this is a failing check
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userPoolArn + "/cognito-user-pool-mfa",
+                "Id": f"{userPoolArn}/cognito-user-pool-mfa",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userPoolId,
                 "AwsAccountId": awsAccountId,
@@ -375,13 +365,11 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                 "Severity": {"Label": "HIGH"},
                 "Confidence": 99,
                 "Title": "[Cognito-IdP.3] Cognito user pools should enforce multi factor authentication (MFA)",
-                "Description": "Cognito user pool "
-                + userPoolArn
-                + " does not enforce multi factor authentication (MFA). AWS recommends enabling MFA for all accounts that have a console password. Enabling MFA provides increased security for console access because it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential. Refer to the remediation instructions to remediate this behavior",
+                "Description": f"Cognito user pool {userPoolArn} does not enforce multi factor authentication (MFA). AWS recommends enabling MFA for all accounts that have a console password. Enabling MFA provides increased security for console access because it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential. Refer to the remediation instructions to remediate this behavior.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "To ensure you Cognito user pools enforce MFA refer to the Adding Multi-Factor Authentication (MFA) to a User Pool section of the Amazon Cognito Developer Guide",
-                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html",
+                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -391,7 +379,7 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                         "Id": userPoolArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"UserPoolId": userPoolId}},
+                        "Details": {"Other": {"UserPoolId": userPoolId}}
                     }
                 ],
                 "Compliance": {
@@ -420,17 +408,17 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                         "ISO 27001:2013 A.9.2.6",
                         "ISO 27001:2013 A.9.3.1",
                         "ISO 27001:2013 A.9.4.2",
-                        "ISO 27001:2013 A.9.4.3",
-                    ],
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
+                "RecordState": "ACTIVE"
             }
             yield finding
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userPoolArn + "/cognito-user-pool-mfa",
+                "Id": f"{userPoolArn}/cognito-user-pool-mfa",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userPoolId,
                 "AwsAccountId": awsAccountId,
@@ -441,13 +429,11 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
                 "Title": "[Cognito-IdP.3] Cognito user pools should enforce multi factor authentication (MFA)",
-                "Description": "Cognito user pool "
-                + userPoolArn
-                + " enforces multi factor authentication (MFA).",
+                "Description": f"Cognito user pool {userPoolArn} enforces multi factor authentication (MFA).",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "To ensure you Cognito user pools enforce MFA refer to the Adding Multi-Factor Authentication (MFA) to a User Pool section of the Amazon Cognito Developer Guide",
-                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html",
+                        "Url": "https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -457,7 +443,7 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                         "Id": userPoolArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"UserPoolId": userPoolId}},
+                        "Details": {"Other": {"UserPoolId": userPoolId}}
                     }
                 ],
                 "Compliance": {
@@ -486,10 +472,10 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                         "ISO 27001:2013 A.9.2.6",
                         "ISO 27001:2013 A.9.3.1",
                         "ISO 27001:2013 A.9.4.2",
-                        "ISO 27001:2013 A.9.4.3",
-                    ],
+                        "ISO 27001:2013 A.9.4.3"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
-                "RecordState": "ARCHIVED",
+                "RecordState": "ARCHIVED"
             }
             yield finding

--- a/eeauditor/auditors/aws/Amazon_CognitoIdP_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CognitoIdP_Auditor.py
@@ -18,6 +18,7 @@
 #specific language governing permissions and limitations
 #under the License.
 import boto3
+import botocore
 import datetime
 from check_register import CheckRegister, accumulate_paged_results
 
@@ -25,6 +26,7 @@ registry = CheckRegister()
 
 # boto3 clients
 cognitoidp = boto3.client("cognito-idp")
+wafv2 = boto3.client("wafv2")
 
 # loop through Cognito User Pools
 def list_user_pools(cache):
@@ -38,9 +40,9 @@ def list_user_pools(cache):
     )
     return cache["list_user_pools"]
 
-@registry.register_check("sns")
+@registry.register_check("cognito-idp")
 def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[Cognito-IdP.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards"""
+    """[Cognito.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards"""
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for userpools in list_user_pools(cache)["UserPools"]:
@@ -74,7 +76,7 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Cognito-IdP.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards",
+                "Title": "[Cognito.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards",
                 "Description": f"Cognito user pool {userPoolArn} meets the password guidelines.",
                 "Remediation": {
                     "Recommendation": {
@@ -139,7 +141,7 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "MEDIUM"},
                 "Confidence": 99,
-                "Title": "[Cognito-IdP.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards",
+                "Title": "[Cognito.1] Cognito user pools should have a password policy that meets or exceed AWS CIS Foundations Benchmark standards",
                 "Description": f"Cognito user pool {userPoolArn} does not meet the password guidelines. Password policies, in part, enforce password complexity requirements, setting a password complexity policy increases account resiliency against brute force login attempts. Refer to the remediation instructions to remediate this behavior.",
                 "Remediation": {
                     "Recommendation": {
@@ -191,10 +193,9 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
             }
             yield finding
 
-
-@registry.register_check("sns")
+@registry.register_check("cognito-idp")
 def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[Cognito-IdP.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours"""
+    """[Cognito.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours"""
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for userpools in list_user_pools(cache)["UserPools"]:
@@ -218,7 +219,7 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "MEDIUM"},
                 "Confidence": 99,
-                "Title": "[Cognito-IdP.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours",
+                "Title": "[Cognito.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours",
                 "Description": f"Cognito user pool {userPoolArn} allows temporary passwords to stay valid beyond 24 hours. Password policies, in part, enforce password complexity requirements, setting a password complexity policy increases account resiliency against brute force login attempts. Refer to the remediation instructions if this configuration is not intended.",
                 "Remediation": {
                     "Recommendation": {
@@ -285,7 +286,7 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Cognito-IdP.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours",
+                "Title": "[Cognito.2] Cognito user pools should not allow temporary passwords to stay valid beyond 24 hours",
                 "Description": f"Cognito user pool {userPoolArn} does not allow temporary passwords to stay valid beyond 24 hours.",
                 "Remediation": {
                     "Recommendation": {
@@ -339,9 +340,9 @@ def cognitoidp_temp_password_check(cache: dict, awsAccountId: str, awsRegion: st
             }
             yield finding
 
-@registry.register_check("sns")
+@registry.register_check("cognito-idp")
 def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
-    """[Cognito-IdP.3] Cognito user pools should enforce multi factor authentication (MFA)"""
+    """[Cognito.3] Cognito user pools should enforce multi factor authentication (MFA)"""
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for userpools in list_user_pools(cache)["UserPools"]:
@@ -365,7 +366,7 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "HIGH"},
                 "Confidence": 99,
-                "Title": "[Cognito-IdP.3] Cognito user pools should enforce multi factor authentication (MFA)",
+                "Title": "[Cognito.3] Cognito user pools should enforce multi factor authentication (MFA)",
                 "Description": f"Cognito user pool {userPoolArn} does not enforce multi factor authentication (MFA). AWS recommends enabling MFA for all accounts that have a console password. Enabling MFA provides increased security for console access because it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential. Refer to the remediation instructions to remediate this behavior.",
                 "Remediation": {
                     "Recommendation": {
@@ -429,7 +430,7 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Cognito-IdP.3] Cognito user pools should enforce multi factor authentication (MFA)",
+                "Title": "[Cognito.3] Cognito user pools should enforce multi factor authentication (MFA)",
                 "Description": f"Cognito user pool {userPoolArn} enforces multi factor authentication (MFA).",
                 "Remediation": {
                     "Recommendation": {
@@ -480,3 +481,21 @@ def cognitoidp_mfa_check(cache: dict, awsAccountId: str, awsRegion: str, awsPart
                 "RecordState": "ARCHIVED"
             }
             yield finding
+
+@registry.register_check("cognito-idp")
+def cognitoidp_waf_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[Cognito.4] Cognito user pools should be protected by AWS Web Application Firewall"""
+    # ISO Time
+    iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+    for userpools in list_user_pools(cache)["UserPools"]:
+        userPoolId = str(userpools["Id"])
+        # Get specific user pool info
+        r = cognitoidp.describe_user_pool(UserPoolId=userPoolId)
+        userPoolArn = str(r["UserPool"]["Arn"])
+        # determine if the User Pool ARN is covered by WAFv2
+        # this is a passing check
+        try:
+            wafv2.get_web_acl_for_resource(ResourceArn=userPoolArn)
+        except botocore.exceptions.ClientError as error:
+            if error.response['Error']['Code'] == 'WAFUnavailableEntityException':
+                print('You are not subscribed to AWS Premium Support - cannot use the Health Auditor')

--- a/eeauditor/auditors/aws/Amazon_CognitoIdP_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_CognitoIdP_Auditor.py
@@ -23,9 +23,10 @@ from check_register import CheckRegister, accumulate_paged_results
 
 registry = CheckRegister()
 
+# boto3 clients
 cognitoidp = boto3.client("cognito-idp")
 
-
+# loop through Cognito User Pools
 def list_user_pools(cache):
     response = cache.get("list_user_pools")
     if response:
@@ -63,7 +64,7 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
             # this is a passing check
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userPoolArn + "/cognito-user-pool-password-policy",
+                "Id": f"{userPoolArn}/cognito-user-pool-password-policy",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userPoolId,
                 "awsAccountId": awsAccountId,
@@ -128,7 +129,7 @@ def cognitoidp_cis_password_check(cache: dict, awsAccountId: str, awsRegion: str
             # this is a failing check
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": userPoolArn + "/cognito-user-pool-password-policy",
+                "Id": f"{userPoolArn}/cognito-user-pool-password-policy",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": userPoolId,
                 "AwsAccountId": awsAccountId,

--- a/eeauditor/auditors/aws/Amazon_EBS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_EBS_Auditor.py
@@ -49,17 +49,18 @@ def ebs_volume_attachment_check(cache: dict, awsAccountId: str, awsRegion: str, 
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for volumes in describe_volumes(cache)["Volumes"]:
-        ebsVolumeId = str(volumes["VolumeId"])
-        ebsVolumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}/{ebsVolumeId}"
+        volumeId = str(volumes["VolumeId"])
+        volumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}:volume/{volumeId}"
         ebsAttachments = volumes["Attachments"]
         for attachments in ebsAttachments:
-            ebsAttachmentState = str(attachments["State"])    
+            ebsAttachmentState = str(attachments["State"])
+            # this is a failing check
             if ebsAttachmentState != "attached":
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": ebsVolumeArn + "/ebs-volume-attachment-check",
+                    "Id": f"{volumeArn}/ebs-volume-attachment-check",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": ebsVolumeArn,
+                    "GeneratorId": volumeArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -69,7 +70,7 @@ def ebs_volume_attachment_check(cache: dict, awsAccountId: str, awsRegion: str, 
                     "Confidence": 99,
                     "Title": "[EBS.1] EBS Volumes should be in an attached state",
                     "Description": "EBS Volume "
-                    + ebsVolumeId
+                    + volumeId
                     + " is not in an attached state. Refer to the remediation instructions if this configuration is not intended",
                     "Remediation": {
                         "Recommendation": {
@@ -81,7 +82,7 @@ def ebs_volume_attachment_check(cache: dict, awsAccountId: str, awsRegion: str, 
                     "Resources": [
                         {
                             "Type": "AwsEc2Volume",
-                            "Id": ebsVolumeArn,
+                            "Id": volumeArn,
                             "Partition": awsPartition,
                             "Region": awsRegion
                         }
@@ -103,12 +104,13 @@ def ebs_volume_attachment_check(cache: dict, awsAccountId: str, awsRegion: str, 
                     "RecordState": "ACTIVE",
                 }
                 yield finding
+            # this is a passing check
             else:
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": ebsVolumeArn + "/ebs-volume-attachment-check",
+                    "Id": f"{volumeArn}/ebs-volume-attachment-check",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": ebsVolumeArn,
+                    "GeneratorId": volumeArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -117,7 +119,7 @@ def ebs_volume_attachment_check(cache: dict, awsAccountId: str, awsRegion: str, 
                     "Severity": {"Label": "INFORMATIONAL"},
                     "Confidence": 99,
                     "Title": "[EBS.1] EBS Volumes should be in an attached state",
-                    "Description": "EBS Volume " + ebsVolumeId + " is in an attached state.",
+                    "Description": "EBS Volume " + volumeId + " is in an attached state.",
                     "Remediation": {
                         "Recommendation": {
                             "Text": "If your EBS volume should be attached refer to the Attaching an Amazon EBS Volume to an Instance section of the Amazon Elastic Compute Cloud User Guide",
@@ -128,7 +130,7 @@ def ebs_volume_attachment_check(cache: dict, awsAccountId: str, awsRegion: str, 
                     "Resources": [
                         {
                             "Type": "AwsEc2Volume",
-                            "Id": ebsVolumeArn,
+                            "Id": volumeArn,
                             "Partition": awsPartition,
                             "Region": awsRegion
                         }
@@ -157,17 +159,18 @@ def ebs_volume_delete_on_termination_check(cache: dict, awsAccountId: str, awsRe
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for volumes in describe_volumes(cache)["Volumes"]:
-        ebsVolumeId = str(volumes["VolumeId"])
-        ebsVolumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}/{ebsVolumeId}"
+        volumeId = str(volumes["VolumeId"])
+        volumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}:volume/{volumeId}"
         ebsAttachments = volumes["Attachments"]
         for attachments in ebsAttachments:
             ebsDeleteOnTerminationCheck = str(attachments["DeleteOnTermination"])
+            # this is a failing check
             if ebsDeleteOnTerminationCheck == "False":
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": ebsVolumeArn + "/ebs-volume-delete-on-termination-check",
+                    "Id": f"{volumeArn}/ebs-volume-delete-on-termination-check",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": ebsVolumeArn,
+                    "GeneratorId": volumeArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -177,7 +180,7 @@ def ebs_volume_delete_on_termination_check(cache: dict, awsAccountId: str, awsRe
                     "Confidence": 99,
                     "Title": "[EBS.2] EBS Volumes should be configured to be deleted on termination",
                     "Description": "EBS Volume "
-                    + ebsVolumeId
+                    + volumeId
                     + " is not configured to be deleted on termination. Refer to the remediation instructions if this configuration is not intended",
                     "Remediation": {
                         "Recommendation": {
@@ -189,7 +192,7 @@ def ebs_volume_delete_on_termination_check(cache: dict, awsAccountId: str, awsRe
                     "Resources": [
                         {
                             "Type": "AwsEc2Volume",
-                            "Id": ebsVolumeArn,
+                            "Id": volumeArn,
                             "Partition": awsPartition,
                             "Region": awsRegion
                         }
@@ -211,12 +214,13 @@ def ebs_volume_delete_on_termination_check(cache: dict, awsAccountId: str, awsRe
                     "RecordState": "ACTIVE",
                 }
                 yield finding
+            # this is a passing check
             else:
                 finding = {
                     "SchemaVersion": "2018-10-08",
-                    "Id": ebsVolumeArn + "/ebs-volume-delete-on-termination-check",
+                    "Id": f"{volumeArn}/ebs-volume-delete-on-termination-check",
                     "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                    "GeneratorId": ebsVolumeArn,
+                    "GeneratorId": volumeArn,
                     "AwsAccountId": awsAccountId,
                     "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                     "FirstObservedAt": iso8601Time,
@@ -226,7 +230,7 @@ def ebs_volume_delete_on_termination_check(cache: dict, awsAccountId: str, awsRe
                     "Confidence": 99,
                     "Title": "[EBS.2] EBS Volumes should be configured to be deleted on termination",
                     "Description": "EBS Volume "
-                    + ebsVolumeId
+                    + volumeId
                     + " is configured to be deleted on termination.",
                     "Remediation": {
                         "Recommendation": {
@@ -238,7 +242,7 @@ def ebs_volume_delete_on_termination_check(cache: dict, awsAccountId: str, awsRe
                     "Resources": [
                         {
                             "Type": "AwsEc2Volume",
-                            "Id": ebsVolumeArn,
+                            "Id": volumeArn,
                             "Partition": awsPartition,
                             "Region": awsRegion
                         }
@@ -267,15 +271,16 @@ def ebs_volume_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, 
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     for volumes in describe_volumes(cache)["Volumes"]:
-        ebsVolumeId = str(volumes["VolumeId"])
-        ebsVolumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}/{ebsVolumeId}"
-        ebsEncryptionCheck = str(volumes["Encrypted"])
-        if ebsEncryptionCheck == "False":
+        volumeId = str(volumes["VolumeId"])
+        volumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}:volume/{volumeId}"
+        ebsEncryptionCheck = volumes["Encrypted"]
+        # this is a failing check
+        if ebsEncryptionCheck == False:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": ebsVolumeArn + "/ebs-volume-encryption-check",
+                "Id": f"{volumeArn}/ebs-volume-encryption-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                "GeneratorId": ebsVolumeArn,
+                "GeneratorId": volumeArn,
                 "AwsAccountId": awsAccountId,
                 "Types": [
                     "Software and Configuration Checks/AWS Security Best Practices",
@@ -288,7 +293,7 @@ def ebs_volume_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, 
                 "Confidence": 99,
                 "Title": "[EBS.3] EBS Volumes should be encrypted",
                 "Description": "EBS Volume "
-                + ebsVolumeId
+                + volumeId
                 + " is not encrypted. Refer to the remediation instructions if this configuration is not intended",
                 "Remediation": {
                     "Recommendation": {
@@ -300,7 +305,7 @@ def ebs_volume_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, 
                 "Resources": [
                     {
                         "Type": "AwsEc2Volume",
-                        "Id": ebsVolumeArn,
+                        "Id": volumeArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
                         "Details": {
@@ -318,19 +323,20 @@ def ebs_volume_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, 
                         "NIST SP 800-53 SC-12",
                         "NIST SP 800-53 SC-28",
                         "AICPA TSC CC6.1",
-                        "ISO 27001:2013 A.8.2.3",
-                    ],
+                        "ISO 27001:2013 A.8.2.3"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
+                "RecordState": "ACTIVE"
             }
             yield finding
+        # this is a passing check
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": ebsVolumeArn + "/ebs-volume-encryption-check",
+                "Id": f"{volumeArn}/ebs-volume-encryption-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                "GeneratorId": ebsVolumeArn,
+                "GeneratorId": volumeArn,
                 "AwsAccountId": awsAccountId,
                 "Types": [
                     "Software and Configuration Checks/AWS Security Best Practices",
@@ -342,7 +348,7 @@ def ebs_volume_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, 
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
                 "Title": "[EBS.3] EBS Volumes should be encrypted",
-                "Description": f"EBS Volume {ebsVolumeId} is encrypted.",
+                "Description": f"EBS Volume {volumeId} is encrypted.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "If your EBS volume should be encrypted refer to the Amazon EBS Encryption section of the Amazon Elastic Compute Cloud User Guide",
@@ -353,7 +359,7 @@ def ebs_volume_encryption_check(cache: dict, awsAccountId: str, awsRegion: str, 
                 "Resources": [
                     {
                         "Type": "AwsEc2Volume",
-                        "Id": ebsVolumeArn,
+                        "Id": volumeArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
                         "Details": {
@@ -387,11 +393,12 @@ def ebs_snapshot_encryption_check(cache: dict, awsAccountId: str, awsRegion: str
     for snapshots in describe_snapshots(cache, awsAccountId)["Snapshots"]:
         snapshotId = str(snapshots["SnapshotId"])
         snapshotArn = f"arn:{awsPartition}:ec2:{awsRegion}::snapshot/{snapshotId}"
-        snapshotEncryptionCheck = str(snapshots["Encrypted"])
-        if snapshotEncryptionCheck == "False":
+        snapshotEncryptionCheck = snapshots["Encrypted"]
+        # this is a failing check
+        if snapshotEncryptionCheck == False:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": snapshotArn + "/ebs-snapshot-encryption-check",
+                "Id": f"{snapshotArn}/ebs-snapshot-encryption-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": snapshotArn,
                 "AwsAccountId": awsAccountId,
@@ -437,17 +444,18 @@ def ebs_snapshot_encryption_check(cache: dict, awsAccountId: str, awsRegion: str
                         "NIST SP 800-53 SC-12",
                         "NIST SP 800-53 SC-28",
                         "AICPA TSC CC6.1",
-                        "ISO 27001:2013 A.8.2.3",
-                    ],
+                        "ISO 27001:2013 A.8.2.3"
+                    ]
                 },
                 "Workflow": {"Status": "NEW"},
-                "RecordState": "ACTIVE",
+                "RecordState": "ACTIVE"
             }
             yield finding
+        # this is a passing check
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": snapshotArn + "/ebs-snapshot-encryption-check",
+                "Id": f"{snapshotArn}/ebs-snapshot-encryption-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": snapshotArn,
                 "AwsAccountId": awsAccountId,
@@ -491,11 +499,11 @@ def ebs_snapshot_encryption_check(cache: dict, awsAccountId: str, awsRegion: str
                         "NIST SP 800-53 SC-12",
                         "NIST SP 800-53 SC-28",
                         "AICPA TSC CC6.1",
-                        "ISO 27001:2013 A.8.2.3",
-                    ],
+                        "ISO 27001:2013 A.8.2.3"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
-                "RecordState": "ARCHIVED",
+                "RecordState": "ARCHIVED"
             }
             yield finding
 
@@ -507,19 +515,23 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
     for snapshots in describe_snapshots(cache, awsAccountId)["Snapshots"]:
         snapshotId = str(snapshots["SnapshotId"])
         snapshotArn = f"arn:{awsPartition}:ec2:{awsRegion}::snapshot/{snapshotId}"
-        response = ec2.describe_snapshot_attribute(
-            Attribute="createVolumePermission", SnapshotId=snapshotId, DryRun=False
+        # determine if there are any permissions to share the snapshot
+        r = ec2.describe_snapshot_attribute(
+            Attribute="createVolumePermission",
+            SnapshotId=snapshotId,
+            DryRun=False
         )
-        if str(response["CreateVolumePermissions"]) == "[]":
+        # this is a passing check
+        if not r["CreateVolumePermissions"]:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": snapshotArn + "/ebs-snapshot-public-share-check",
+                "Id": f"{snapshotArn}/ebs-snapshot-public-share-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": snapshotArn,
                 "AwsAccountId": awsAccountId,
                 "Types": [
                     "Software and Configuration Checks/AWS Security Best Practices",
-                    "Effects/Data Exposure",
+                    "Effects/Data Exposure"
                 ],
                 "FirstObservedAt": iso8601Time,
                 "CreatedAt": iso8601Time,
@@ -527,11 +539,11 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
                 "Title": "[EBS.5] EBS Snapshots should not be public",
-                "Description": "EBS Snapshot " + snapshotId + " is private.",
+                "Description": f"EBS Snapshot {snapshotId} is private.",
                 "Remediation": {
                     "Recommendation": {
                         "Text": "If your EBS snapshot should not be public refer to the Sharing an Amazon EBS Snapshot section of the Amazon Elastic Compute Cloud User Guide",
-                        "Url": "https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-modifying-snapshot-permissions.html",
+                        "Url": "https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-modifying-snapshot-permissions.html"
                     }
                 },
                 "ProductFields": {"Product Name": "ElectricEye"},
@@ -562,27 +574,28 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                         "ISO 27001:2013 A.6.2.2",
                         "ISO 27001:2013 A.11.2.6",
                         "ISO 27001:2013 A.13.1.1",
-                        "ISO 27001:2013 A.13.2.1",
-                    ],
+                        "ISO 27001:2013 A.13.2.1"
+                    ]
                 },
                 "Workflow": {"Status": "RESOLVED"},
-                "RecordState": "ARCHIVED",
+                "RecordState": "ARCHIVED"
             }
             yield finding
         else:
-            for permissions in response["CreateVolumePermissions"]:
+            for permissions in r["CreateVolumePermissions"]:
                 # {'Group': 'all'} denotes public
                 # you should still audit accounts you have shared
+                # this is a failing check
                 if str(permissions) == "{'Group': 'all'}":
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": snapshotArn + "/ebs-snapshot-public-share-check",
+                        "Id": f"{snapshotArn}/ebs-snapshot-public-share-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": snapshotArn,
                         "AwsAccountId": awsAccountId,
                         "Types": [
                             "Software and Configuration Checks/AWS Security Best Practices",
-                            "Effects/Data Exposure",
+                            "Effects/Data Exposure"
                         ],
                         "FirstObservedAt": iso8601Time,
                         "CreatedAt": iso8601Time,
@@ -590,13 +603,11 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                         "Severity": {"Label": "CRITICAL"},
                         "Confidence": 99,
                         "Title": "[EBS.5] EBS Snapshots should not be public",
-                        "Description": "EBS Snapshot "
-                        + snapshotId
-                        + " is public. Refer to the remediation instructions to remediate this behavior",
+                        "Description": f"EBS Snapshot {snapshotId} is public. Snapshots that are public are restorable into Volumes or Amazon Machine Images (AMIs) by anyone with an AWS Account, if sensitive data is contained on the snapshot then adversaries can easily harvest it. Ensure you carefully examine the data stored onto root volumes as well as their permissions. Refer to the remediation instructions to remediate this behavior.",
                         "Remediation": {
                             "Recommendation": {
                                 "Text": "If your EBS snapshot should not be public refer to the Sharing an Amazon EBS Snapshot section of the Amazon Elastic Compute Cloud User Guide",
-                                "Url": "https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-modifying-snapshot-permissions.html",
+                                "Url": "https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-modifying-snapshot-permissions.html"
                             }
                         },
                         "ProductFields": {"Product Name": "ElectricEye"},
@@ -627,23 +638,24 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                                 "ISO 27001:2013 A.6.2.2",
                                 "ISO 27001:2013 A.11.2.6",
                                 "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1",
-                            ],
+                                "ISO 27001:2013 A.13.2.1"
+                            ]
                         },
                         "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
+                        "RecordState": "ACTIVE"
                     }
                     yield finding
                 else:
+                    # this is an active check, but not failing
                     finding = {
                         "SchemaVersion": "2018-10-08",
-                        "Id": snapshotArn + "/ebs-snapshot-public-share-check",
+                        "Id": f"{snapshotArn}/ebs-snapshot-public-share-check",
                         "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                         "GeneratorId": snapshotArn,
                         "AwsAccountId": awsAccountId,
                         "Types": [
                             "Software and Configuration Checks/AWS Security Best Practices",
-                            "Effects/Data Exposure",
+                            "Effects/Data Exposure"
                         ],
                         "FirstObservedAt": iso8601Time,
                         "CreatedAt": iso8601Time,
@@ -651,13 +663,11 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                         "Severity": {"Label": "INFORMATIONAL"},
                         "Confidence": 99,
                         "Title": "[EBS.5] EBS Snapshots should not be public",
-                        "Description": "EBS Snapshot "
-                        + snapshotId
-                        + " is private, however, this snapshot has been identified as being shared with other accounts. You should audit these accounts to ensure they are still authorized to have this snapshot shared with them.",
+                        "Description": f"EBS Snapshot {snapshotId} is private, however, this snapshot has been identified as being shared with other accounts. You should audit these accounts to ensure they are still authorized to have this snapshot shared with them.",
                         "Remediation": {
                             "Recommendation": {
                                 "Text": "If your EBS snapshot should not be public refer to the Sharing an Amazon EBS Snapshot section of the Amazon Elastic Compute Cloud User Guide",
-                                "Url": "https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-modifying-snapshot-permissions.html",
+                                "Url": "https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-modifying-snapshot-permissions.html"
                             }
                         },
                         "ProductFields": {"Product Name": "ElectricEye"},
@@ -688,26 +698,28 @@ def ebs_snapshot_public_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                                 "ISO 27001:2013 A.6.2.2",
                                 "ISO 27001:2013 A.11.2.6",
                                 "ISO 27001:2013 A.13.1.1",
-                                "ISO 27001:2013 A.13.2.1",
-                            ],
+                                "ISO 27001:2013 A.13.2.1"
+                            ]
                         },
                         "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
+                        "RecordState": "ACTIVE"
                     }
                     yield finding
+                # break the loop since we already evaluated
+                break
 
 @registry.register_check("ec2")
 def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
     """[EBS.6] Account-level EBS Volume encryption should be enabled"""
-    response = ec2.get_ebs_encryption_by_default(DryRun=False)
     # ISO Time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
-    if str(response["EbsEncryptionByDefault"]) == "False":
+    # this is a failing check
+    if ec2.get_ebs_encryption_by_default(DryRun=False)["EbsEncryptionByDefault"] == False:
         finding = {
             "SchemaVersion": "2018-10-08",
-            "Id": awsAccountId + awsRegion + "/ebs-account-encryption-check",
+            "Id": f"{awsAccountId}{awsRegion}/ebs-account-encryption-check",
             "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-            "GeneratorId": awsAccountId + "/" + awsRegion,
+            "GeneratorId": f"{awsAccountId}{awsRegion}",
             "AwsAccountId": awsAccountId,
             "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
             "FirstObservedAt": iso8601Time,
@@ -716,15 +728,11 @@ def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsR
             "Severity": {"Label": "MEDIUM"},
             "Confidence": 99,
             "Title": "[EBS.6] Account-level EBS Volume encryption should be enabled",
-            "Description": "Account-level EBS volume encryption is not enabled for AWS Account "
-            + awsAccountId
-            + " in "
-            + awsRegion
-            + ". Refer to the remediation instructions if this configuration is not intended",
+            "Description": f"Account-level EBS volume encryption is not enabled for AWS Account {awsAccountId} in {awsRegion}. Refer to the remediation instructions if this configuration is not intended.",
             "Remediation": {
                 "Recommendation": {
                     "Text": "For information on Account-level encryption refer to the Encryption by Default to an Instance section of the Amazon Elastic Compute Cloud User Guide",
-                    "Url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default",
+                    "Url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default"
                 }
             },
             "ProductFields": {"Product Name": "ElectricEye"},
@@ -733,7 +741,7 @@ def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsR
                     "Type": "AwsAccount",
                     "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
                     "Partition": awsPartition,
-                    "Region": awsRegion,
+                    "Region": awsRegion
                 }
             ],
             "Compliance": {
@@ -744,19 +752,20 @@ def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsR
                     "NIST SP 800-53 SC-12",
                     "NIST SP 800-53 SC-28",
                     "AICPA TSC CC6.1",
-                    "ISO 27001:2013 A.8.2.3",
-                ],
+                    "ISO 27001:2013 A.8.2.3"
+                ]
             },
             "Workflow": {"Status": "NEW"},
-            "RecordState": "ACTIVE",
+            "RecordState": "ACTIVE"
         }
         yield finding
+    # this is a passing check
     else:
         finding = {
             "SchemaVersion": "2018-10-08",
-            "Id": awsAccountId + awsRegion + "/ebs-account-encryption-check",
+            "Id": f"{awsAccountId}{awsRegion}/ebs-account-encryption-check",
             "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-            "GeneratorId": awsAccountId + "/" + awsRegion,
+            "GeneratorId": f"{awsAccountId}{awsRegion}",
             "AwsAccountId": awsAccountId,
             "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
             "FirstObservedAt": iso8601Time,
@@ -765,15 +774,11 @@ def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsR
             "Severity": {"Label": "INFORMATIONAL"},
             "Confidence": 99,
             "Title": "[EBS.6] Account-level EBS Volume encryption should be enabled",
-            "Description": "Account-level EBS volume encryption is enabled for AWS Account "
-            + awsAccountId
-            + " in "
-            + awsRegion
-            + ".",
+            "Description": "Account-level EBS volume encryption is enabled for AWS Account {awsAccountId} in {awsRegion}.",
             "Remediation": {
                 "Recommendation": {
                     "Text": "For information on Account-level encryption refer to the Encryption by Default to an Instance section of the Amazon Elastic Compute Cloud User Guide",
-                    "Url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default",
+                    "Url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default"
                 }
             },
             "ProductFields": {"Product Name": "ElectricEye"},
@@ -782,7 +787,7 @@ def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsR
                     "Type": "AwsAccount",
                     "Id": f"{awsPartition.upper()}::::Account:{awsAccountId}",
                     "Partition": awsPartition,
-                    "Region": awsRegion,
+                    "Region": awsRegion
                 }
             ],
             "Compliance": {
@@ -793,11 +798,11 @@ def ebs_account_encryption_by_default_check(cache: dict, awsAccountId: str, awsR
                     "NIST SP 800-53 SC-12",
                     "NIST SP 800-53 SC-28",
                     "AICPA TSC CC6.1",
-                    "ISO 27001:2013 A.8.2.3",
-                ],
+                    "ISO 27001:2013 A.8.2.3"
+                ]
             },
             "Workflow": {"Status": "RESOLVED"},
-            "RecordState": "ARCHIVED",
+            "RecordState": "ARCHIVED"
         }
         yield finding
 
@@ -807,8 +812,8 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
     # ISO Time
     iso8601Time = (datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat())
     for volumes in describe_volumes(cache)["Volumes"]:
-        ebsVolumeId = str(volumes["VolumeId"])
-        ebsVolumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}/{ebsVolumeId}"
+        volumeId = str(volumes["VolumeId"])
+        volumeArn = f"arn:{awsPartition}:ec2:{awsRegion}:{awsAccountId}:volume/{volumeId}"
         # Check if there is a volume
         try:
             snapshotId = str(volumes["SnapshotId"])
@@ -818,9 +823,9 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
         if snapshotId != None:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": ebsVolumeArn + "/ebs-volume-snapshot-check",
+                "Id": f"{volumeArn}/ebs-volume-snapshot-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                "GeneratorId": f"{ebsVolumeArn}/{snapshotId}",
+                "GeneratorId": f"{volumeArn}/{snapshotId}",
                 "AwsAccountId": awsAccountId,
                 "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                 "FirstObservedAt": iso8601Time,
@@ -830,7 +835,7 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                 "Confidence": 99,
                 "Title": "[EBS.7] EBS Volumes should have snapshots",
                 "Description": "EBS Volume "
-                + ebsVolumeId
+                + volumeId
                 + " has a snapshot which can promote cyber resilience due to a viable backup.",
                 "Remediation": {
                     "Recommendation": {
@@ -842,7 +847,7 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                 "Resources": [
                     {
                         "Type": "AwsEc2Volume",
-                        "Id": ebsVolumeArn,
+                        "Id": volumeArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
                         "Details": {
@@ -876,9 +881,9 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
         else:
             finding = {
                 "SchemaVersion": "2018-10-08",
-                "Id": ebsVolumeArn + "/ebs-volume-snapshot-check",
+                "Id": f"{volumeArn}/ebs-volume-snapshot-check",
                 "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
-                "GeneratorId": f"{ebsVolumeArn}/{snapshotId}",
+                "GeneratorId": f"{volumeArn}/{snapshotId}",
                 "AwsAccountId": awsAccountId,
                 "Types": ["Software and Configuration Checks/AWS Security Best Practices"],
                 "FirstObservedAt": iso8601Time,
@@ -888,7 +893,7 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                 "Confidence": 99,
                 "Title": "[EBS.7] EBS Volumes should have snapshots",
                 "Description": "EBS Volume "
-                + ebsVolumeId
+                + volumeId
                 + " does not have a snapshot which can reduce cyber resilience due to a lack of a viable backup. Refer to the remediation instructions if this configuration is not intended",
                 "Remediation": {
                     "Recommendation": {
@@ -900,7 +905,7 @@ def ebs_volume_snapshot_check(cache: dict, awsAccountId: str, awsRegion: str, aw
                 "Resources": [
                     {
                         "Type": "AwsEc2Volume",
-                        "Id": ebsVolumeArn,
+                        "Id": volumeArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
                         "Details": {

--- a/eeauditor/auditors/aws/Amazon_Shield_Advanced_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_Shield_Advanced_Auditor.py
@@ -1187,9 +1187,9 @@ def shield_advanced_global_accelerator_protection_check(cache: dict, awsAccountI
                     }
                     yield finding
 
-
 @registry.register_check("shield")
 def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str) -> dict:
+    """[ShieldAdvanced.10] AWS Shield resources under attack in the last two weeks should be investigated"""
     # ISO time
     iso8601Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     response = shield.list_attacks(
@@ -1200,7 +1200,8 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
             'ToExclusive': datetime.datetime.utcnow()
         }
     )
-    if len(response['AttackSummaries']) == 0:
+    # this is a passing check
+    if not response['AttackSummaries']:
         finding = {
             "SchemaVersion": "2018-10-08",
             "Id": awsAccountId + "/shield-adv-subscription-latest-attacks",
@@ -1213,7 +1214,7 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
             "UpdatedAt": iso8601Time,
             "Severity": {"Label": "INFORMATIONAL"},
             "Confidence": 99,
-            "Title": "[ShieldAdvanced.9] Resources under attack in the last week",
+            "Title": "[ShieldAdvanced.10] AWS Shield resources under attack in the last two weeks should be investigated",
             "Description": f"The resources in {awsAccountId} have not had an attack mitigated by AWS Shield Advanced in the last week",
             "Remediation": {
                 "Recommendation": {
@@ -1247,6 +1248,7 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
             "RecordState": "ARCHIVED",
         }
         yield finding
+    # this is a failing check
     else:
         finding = {
             "SchemaVersion": "2018-10-08",
@@ -1260,7 +1262,7 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
             "UpdatedAt": iso8601Time,
             "Severity": {"Label": "MEDIUM"},
             "Confidence": 99,
-            "Title": "[ShieldAdvanced.9] Resources under attack in the last week",
+            "Title": "[ShieldAdvanced.10] AWS Shield resources under attack in the last two weeks should be investigated",
             "Description": f"The resources in {awsAccountId} have had at least one attack mitigated by AWS Shield Advanced in the last week",
             "Remediation": {
                 "Recommendation": {
@@ -1287,8 +1289,8 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
                     "AICPA TSC CC6.1",
                     "ISO 27001:2013 A.8.1.1",
                     "ISO 27001:2013 A.8.1.2",
-                    "ISO 27001:2013 A.12.5.1",
-                ],
+                    "ISO 27001:2013 A.12.5.1"
+                ]
             },
             "Workflow": {"Status": "NEW"},
             "RecordState": "ACTIVE",

--- a/eeauditor/auditors/aws/Amazon_Shield_Advanced_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_Shield_Advanced_Auditor.py
@@ -99,6 +99,9 @@ def shield_advanced_route_53_protection_check(cache: dict, awsAccountId: str, aw
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
                         "ISO 27001:2013 A.17.2.1",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1498"
                     ],
                 },
                 "Workflow": {"Status": "RESOLVED"},
@@ -157,6 +160,9 @@ def shield_advanced_route_53_protection_check(cache: dict, awsAccountId: str, aw
                             "ISO 27001:2013 A.17.1.1",
                             "ISO 27001:2013 A.17.1.2",
                             "ISO 27001:2013 A.17.2.1",
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1498"
                         ],
                     },
                     "Workflow": {"Status": "NEW"},
@@ -223,6 +229,9 @@ def shield_advanced_elb_protection_check(cache: dict, awsAccountId: str, awsRegi
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
                         "ISO 27001:2013 A.17.2.1",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1498"
                     ],
                 },
                 "Workflow": {"Status": "RESOLVED"},
@@ -281,6 +290,9 @@ def shield_advanced_elb_protection_check(cache: dict, awsAccountId: str, awsRegi
                             "ISO 27001:2013 A.17.1.1",
                             "ISO 27001:2013 A.17.1.2",
                             "ISO 27001:2013 A.17.2.1",
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1498"
                         ],
                     },
                     "Workflow": {"Status": "NEW"},
@@ -362,6 +374,9 @@ def shield_advanced_elb_v2_protection_check(cache: dict, awsAccountId: str, awsR
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
                         "ISO 27001:2013 A.17.2.1",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1498"
                     ],
                 },
                 "Workflow": {"Status": "RESOLVED"},
@@ -430,6 +445,9 @@ def shield_advanced_elb_v2_protection_check(cache: dict, awsAccountId: str, awsR
                             "ISO 27001:2013 A.17.1.1",
                             "ISO 27001:2013 A.17.1.2",
                             "ISO 27001:2013 A.17.2.1",
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1498"
                         ],
                     },
                     "Workflow": {"Status": "NEW"},
@@ -496,6 +514,9 @@ def shield_advanced_eip_protection_check(cache: dict, awsAccountId: str, awsRegi
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
                         "ISO 27001:2013 A.17.2.1",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1498"
                     ],
                 },
                 "Workflow": {"Status": "RESOLVED"},
@@ -554,6 +575,9 @@ def shield_advanced_eip_protection_check(cache: dict, awsAccountId: str, awsRegi
                             "ISO 27001:2013 A.17.1.1",
                             "ISO 27001:2013 A.17.1.2",
                             "ISO 27001:2013 A.17.2.1",
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1498"
                         ],
                     },
                     "Workflow": {"Status": "NEW"},
@@ -625,6 +649,9 @@ def shield_advanced_cloudfront_protection_check(cache: dict, awsAccountId: str, 
                         "ISO 27001:2013 A.17.1.1",
                         "ISO 27001:2013 A.17.1.2",
                         "ISO 27001:2013 A.17.2.1",
+                        "MITRE ATT&CK T1595",
+                        "MITRE ATT&CK T1590",
+                        "MITRE ATT&CK T1498"
                     ],
                 },
                 "Workflow": {"Status": "RESOLVED"},
@@ -685,6 +712,9 @@ def shield_advanced_cloudfront_protection_check(cache: dict, awsAccountId: str, 
                             "ISO 27001:2013 A.17.1.1",
                             "ISO 27001:2013 A.17.1.2",
                             "ISO 27001:2013 A.17.2.1",
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1498"
                         ],
                     },
                     "Workflow": {"Status": "NEW"},
@@ -1119,7 +1149,10 @@ def shield_advanced_global_accelerator_protection_check(cache: dict, awsAccountI
                             "ISO 27001:2013 A.11.1.4",
                             "ISO 27001:2013 A.17.1.1",
                             "ISO 27001:2013 A.17.1.2",
-                            "ISO 27001:2013 A.17.2.1"
+                            "ISO 27001:2013 A.17.2.1",
+                            "MITRE ATT&CK T1595",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1498"
                         ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
@@ -1179,7 +1212,10 @@ def shield_advanced_global_accelerator_protection_check(cache: dict, awsAccountI
                                 "ISO 27001:2013 A.11.1.4",
                                 "ISO 27001:2013 A.17.1.1",
                                 "ISO 27001:2013 A.17.1.2",
-                                "ISO 27001:2013 A.17.2.1"
+                                "ISO 27001:2013 A.17.2.1",
+                                "MITRE ATT&CK T1595",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1498"
                             ]
                         },
                         "Workflow": {"Status": "NEW"},
@@ -1219,7 +1255,7 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
             "Remediation": {
                 "Recommendation": {
                     "Text": "View the docs for more details about how to ensure your AWS environments are protected against DDOS attacks.",
-                    "Url": "https://docs.aws.amazon.com/waf/latest/developerguide/ddos-manage-protected-resources.html",
+                    "Url": "https://docs.aws.amazon.com/waf/latest/developerguide/ddos-manage-protected-resources.html"
                 }
             },
             "ProductFields": {"Product Name": "ElectricEye"},
@@ -1242,10 +1278,13 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
                     "ISO 27001:2013 A.8.1.1",
                     "ISO 27001:2013 A.8.1.2",
                     "ISO 27001:2013 A.12.5.1",
-                ],
+                    "MITRE ATT&CK T1595",
+                    "MITRE ATT&CK T1590",
+                    "MITRE ATT&CK T1498"
+                ]
             },
             "Workflow": {"Status": "RESOLVED"},
-            "RecordState": "ARCHIVED",
+            "RecordState": "ARCHIVED"
         }
         yield finding
     # this is a failing check
@@ -1289,10 +1328,13 @@ def shield_advanced_subscription_latest_attacks(cache: dict, awsAccountId: str, 
                     "AICPA TSC CC6.1",
                     "ISO 27001:2013 A.8.1.1",
                     "ISO 27001:2013 A.8.1.2",
-                    "ISO 27001:2013 A.12.5.1"
+                    "ISO 27001:2013 A.12.5.1",
+                    "MITRE ATT&CK T1595",
+                    "MITRE ATT&CK T1590",
+                    "MITRE ATT&CK T1498"
                 ]
             },
             "Workflow": {"Status": "NEW"},
-            "RecordState": "ACTIVE",
+            "RecordState": "ACTIVE"
         }
         yield finding

--- a/eeauditor/auditors/aws/Shodan_Auditor.py
+++ b/eeauditor/auditors/aws/Shodan_Auditor.py
@@ -124,10 +124,16 @@ def public_ec2_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -194,10 +200,16 @@ def public_ec2_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
 
@@ -270,10 +282,16 @@ def public_alb_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -341,10 +359,16 @@ def public_alb_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
         else:
@@ -424,10 +448,16 @@ def public_rds_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -496,10 +526,16 @@ def public_rds_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
         else:
@@ -585,10 +621,16 @@ def public_es_domain_shodan_check(cache: dict, awsAccountId: str, awsRegion: str
                                 "ISO 27001:2013 A.12.4.1",
                                 "ISO 27001:2013 A.16.1.1",
                                 "ISO 27001:2013 A.16.1.4",
-                            ],
+                                "MITRE ATT&CK T1040",
+                                "MITRE ATT&CK T1046",
+                                "MITRE ATT&CK T1580",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1592",
+                                "MITRE ATT&CK T1595"
+                            ]
                         },
                         "Workflow": {"Status": "RESOLVED"},
-                        "RecordState": "ARCHIVED",
+                        "RecordState": "ARCHIVED"
                     }
                     yield finding
                 else:
@@ -659,10 +701,16 @@ def public_es_domain_shodan_check(cache: dict, awsAccountId: str, awsRegion: str
                                 "ISO 27001:2013 A.12.4.1",
                                 "ISO 27001:2013 A.16.1.1",
                                 "ISO 27001:2013 A.16.1.4",
-                            ],
+                                "MITRE ATT&CK T1040",
+                                "MITRE ATT&CK T1046",
+                                "MITRE ATT&CK T1580",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1592",
+                                "MITRE ATT&CK T1595"
+                            ]
                         },
                         "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
+                        "RecordState": "ACTIVE"
                     }
                     yield finding
             else:
@@ -733,10 +781,16 @@ def public_clb_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -800,10 +854,16 @@ def public_clb_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
         else:
@@ -872,10 +932,16 @@ def public_dms_replication_instance_shodan_check(cache: dict, awsAccountId: str,
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -937,10 +1003,16 @@ def public_dms_replication_instance_shodan_check(cache: dict, awsAccountId: str,
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
         else:
@@ -1023,10 +1095,16 @@ def public_amazon_mq_broker_shodan_check(cache: dict, awsAccountId: str, awsRegi
                                 "ISO 27001:2013 A.12.4.1",
                                 "ISO 27001:2013 A.16.1.1",
                                 "ISO 27001:2013 A.16.1.4",
-                            ],
+                                "MITRE ATT&CK T1040",
+                                "MITRE ATT&CK T1046",
+                                "MITRE ATT&CK T1580",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1592",
+                                "MITRE ATT&CK T1595"
+                            ]
                         },
                         "Workflow": {"Status": "RESOLVED"},
-                        "RecordState": "ARCHIVED",
+                        "RecordState": "ARCHIVED"
                     }
                     yield finding
                 else:
@@ -1082,10 +1160,16 @@ def public_amazon_mq_broker_shodan_check(cache: dict, awsAccountId: str, awsRegi
                                 "ISO 27001:2013 A.12.4.1",
                                 "ISO 27001:2013 A.16.1.1",
                                 "ISO 27001:2013 A.16.1.4",
-                            ],
+                                "MITRE ATT&CK T1040",
+                                "MITRE ATT&CK T1046",
+                                "MITRE ATT&CK T1580",
+                                "MITRE ATT&CK T1590",
+                                "MITRE ATT&CK T1592",
+                                "MITRE ATT&CK T1595"
+                            ]
                         },
                         "Workflow": {"Status": "NEW"},
-                        "RecordState": "ACTIVE",
+                        "RecordState": "ACTIVE"
                     }
                     yield finding
         else:
@@ -1156,10 +1240,16 @@ def cloudfront_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -1222,10 +1312,16 @@ def cloudfront_shodan_check(cache: dict, awsAccountId: str, awsRegion: str, awsP
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding
 
@@ -1298,10 +1394,16 @@ def global_accelerator_shodan_check(cache: dict, awsAccountId: str, awsRegion: s
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "RESOLVED"},
-                    "RecordState": "ARCHIVED",
+                    "RecordState": "ARCHIVED"
                 }
                 yield finding
             else:
@@ -1365,9 +1467,15 @@ def global_accelerator_shodan_check(cache: dict, awsAccountId: str, awsRegion: s
                             "ISO 27001:2013 A.12.4.1",
                             "ISO 27001:2013 A.16.1.1",
                             "ISO 27001:2013 A.16.1.4",
-                        ],
+                            "MITRE ATT&CK T1040",
+                            "MITRE ATT&CK T1046",
+                            "MITRE ATT&CK T1580",
+                            "MITRE ATT&CK T1590",
+                            "MITRE ATT&CK T1592",
+                            "MITRE ATT&CK T1595"
+                        ]
                     },
                     "Workflow": {"Status": "NEW"},
-                    "RecordState": "ACTIVE",
+                    "RecordState": "ACTIVE"
                 }
                 yield finding

--- a/policies/ElectricEye_ECS_Task_Role_Policy.json
+++ b/policies/ElectricEye_ECS_Task_Role_Policy.json
@@ -140,6 +140,7 @@
                 "wafv2:ListWebACLs",
                 "wafv2:GetLoggingConfiguration",
                 "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
                 "cloudfront:ListDistributions",
                 "sagemaker:ListModels",
                 "ds:DescribeDirectories",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-awscli==1.25.40
-boto3==1.24.40
-click==8.1.3
-detect-secrets==1.3.0
-pluginbase==1.0.1
-psycopg2-binary==2.9.3
-pymongo==4.2.0
-python3-nmap==1.5.4
+awscli
+boto3
+click
+detect-secrets
+pluginbase
+psycopg2-binary
+pymongo
+python3-nmap

--- a/terraform-config-files/electric_eye.tf
+++ b/terraform-config-files/electric_eye.tf
@@ -381,6 +381,7 @@ resource "aws_iam_role_policy" "Electric_Eye_Task_Role_Policy" {
                 "wafv2:ListWebACLs",
                 "wafv2:GetLoggingConfiguration",
                 "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
                 "cloudfront:ListDistributions",
                 "sagemaker:ListModels",
                 "ds:DescribeDirectories",


### PR DESCRIPTION
This PR closes out #99 by adding more MITRE ATT&CK Techniques mappings where they made sense (and fit) for certain attack surface and identity related findings. These *could* be far more aggressive but not really worth the rationalization at this time. This PR also continues more performance and ASFF/Pythonic "grammar" fixes and deconflicts Titles if they're still out there (there was at least one). Pinning for `requirements.txt` was also removed since I'm not going to build an SBOM since they're stupid.

- Added 2 new checks for WAF to ELBv2 and Cognito IDP Auditors
- Refactored IAM, EBS and Cognito checks for better cache usage, list comprehensions and clarity -- IAM in particular took a lot of time and now the performance is improved by at least 50%
- Fixed issue with conducting WAFv2 Global, Health and Shield Advanced checks outside of `us-east-1`
- Fixed EBS ARN formats which affected the AWS Backup check and ASFF resource-mapping
- Added MITRE ATT&CK Mappings to Shodan, IAM, Shield Advanced, and WAFv2 checks
- Remove version pinning from `requirements.txt`
- Added new WAF permission for checking Web ACL coverage